### PR TITLE
Supporting any IDbSet<> implementations

### DIFF
--- a/src/Microsoft.Restier.EntityFramework/Microsoft.Restier.EntityFramework.csproj
+++ b/src/Microsoft.Restier.EntityFramework/Microsoft.Restier.EntityFramework.csproj
@@ -43,6 +43,9 @@
     <Compile Include="..\Shared\EnumerableExtensions.cs">
       <Link>Shared\EnumerableExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\Shared\TypeExtensions.cs">
+      <Link>Shared\TypeExtensions.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\SharedResources\SharedResources.EntityFramework.Designer.cs">
       <Link>SharedResources.EntityFramework.Designer.cs</Link>
       <AutoGen>True</AutoGen>

--- a/src/Microsoft.Restier.EntityFramework/Model/ModelMapper.cs
+++ b/src/Microsoft.Restier.EntityFramework/Model/ModelMapper.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Restier.EntityFramework.Model
         /// <c>true</c> if the relevant type was
         /// provided; otherwise, <c>false</c>.
         /// </returns>
-        public bool TryGetRelevantType(
+        public virtual bool TryGetRelevantType(
             DomainContext context,
             string name,
             out Type relevantType)
@@ -61,42 +61,14 @@ namespace Microsoft.Restier.EntityFramework.Model
             if (property != null)
             {
                 var type = property.PropertyType;
-                var parent = GetGenericParent(type);
-                if (parent != null)
+                var genericType = type.FindGenericType(typeof (IDbSet<>));
+                if (genericType != null)
                 {
-                    relevantType = parent.GetGenericArguments()[0];
+                    relevantType = genericType.GetGenericArguments()[0];
                 }
             }
 
             return relevantType != null;
-        }
-
-        /// <summary>
-        /// Finds the <c>IDbSet</c> interface this type implements.
-        /// </summary>
-        /// <param name="type">
-        /// The type of the entity set.
-        /// </param>
-        /// <returns>
-        /// the type itself if it is defined as DbSet or IDbSet,
-        /// type of IDbSet interface implemented by this type if there is;
-        /// otherwise, null
-        /// </returns>
-        private static Type GetGenericParent(Type type)
-        {
-            // Because usage of DbSet very common, first check for it to speed things up
-            if (type.IsGenericType)
-            {
-                var generic = type.GetGenericTypeDefinition();
-                if (generic == typeof(DbSet<>) || generic == typeof(IDbSet<>))
-                {
-                    return type;
-                }
-            }
-
-            return
-                type.GetInterfaces()
-                    .FirstOrDefault(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof (IDbSet<>));
         }
 
         /// <summary>

--- a/src/Microsoft.Restier.EntityFramework/Model/ModelMapper.cs
+++ b/src/Microsoft.Restier.EntityFramework/Model/ModelMapper.cs
@@ -60,14 +60,42 @@ namespace Microsoft.Restier.EntityFramework.Model
             if (property != null)
             {
                 var type = property.PropertyType;
-                if (type.IsGenericType &&
-                    type.GetGenericTypeDefinition() == typeof(DbSet<>))
+                var parent = GetGenericParent(type);
+                if (parent != null)
                 {
-                    relevantType = type.GetGenericArguments()[0];
+                    relevantType = parent.GetGenericArguments()[0];
                 }
             }
 
             return relevantType != null;
+        }
+
+        /// <summary>
+        /// Finds the <c>IDbSet</c> interface this type implements.
+        /// </summary>
+        /// <param name="type">
+        /// The type of the entity set.
+        /// </param>
+        /// <returns>
+        /// the type itself if it is defined as DbSet or IDbSet,
+        /// type of IDbSet interface implemented by this type if there is;
+        /// otherwise, null
+        /// </returns>
+        private Type GetGenericParent(Type type)
+        {
+            // Because usage of DbSet very common, first check for it to speed things up
+            if (type.IsGenericType)
+            {
+                var generic = type.GetGenericTypeDefinition();
+                if (generic == typeof(DbSet<>) || generic == typeof(IDbSet<>))
+                {
+                    return type;
+                }
+            }
+
+            return
+                type.GetInterfaces()
+                    .FirstOrDefault(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof (IDbSet<>));
         }
 
         /// <summary>

--- a/src/Microsoft.Restier.EntityFramework/Model/ModelMapper.cs
+++ b/src/Microsoft.Restier.EntityFramework/Model/ModelMapper.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 #if EF7
 using Microsoft.Data.Entity;
 #else
@@ -81,7 +82,7 @@ namespace Microsoft.Restier.EntityFramework.Model
         /// type of IDbSet interface implemented by this type if there is;
         /// otherwise, null
         /// </returns>
-        private Type GetGenericParent(Type type)
+        private static Type GetGenericParent(Type type)
         {
             // Because usage of DbSet very common, first check for it to speed things up
             if (type.IsGenericType)


### PR DESCRIPTION
Currently, restier does not support IDbSet<> implementations other than DbSet<>. So, if one implements a custom IDbSet<> implementation, or even extends the default implementation, DbSet<>, he/she would not be able to use it with RESTier. Because, as far as i know by inspecting the ModelMapper implementation, any IDbSet<> implementation not being DbSet<> is rejected.

For example, when using IdentityDbContext, because it defines the entity sets as IDbSet<>, i have not be able to work it with Restier.

To overcome this problem, i created my custom IModelMapper by just copying the default one, and adding the changes i included in this commit. Currently i am using this implementation and I don't know if there is any reason for this constraint in the default implementation. So, instead of asking you if this is a proper solution, and explaining what i did in details, i decided to make a pull request.

If it may lead any problems with the rest of the framework, please let me know about it. Because, as i said, currently i use this implementation with my custom IModelMapper implementation which i created just to overcome this problem.