### PR TITLE
This is only a rough design proposal, I don't want to check in, just …

### DIFF
--- a/src/Microsoft.Restier.Core/Api.cs
+++ b/src/Microsoft.Restier.Core/Api.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Restier.Core
             var config = context.Configuration;
             if (config.Model == null)
             {
-                var builder = context.Configuration.GetHookHandler<IModelBuilder>();
+                var builder = context.GetApiService<IModelBuilder>();
                 if (builder != null)
                 {
                     config.Model = await builder.GetModelAsync(new InvocationContext(context), cancellationToken);
@@ -631,7 +631,7 @@ namespace Microsoft.Restier.Core
         {
             Type elementType = null;
 
-            var mapper = context.Configuration.GetHookHandler<IModelMapper>();
+            var mapper = context.GetApiService<IModelMapper>();
             if (mapper != null)
             {
                 if (namespaceName == null)

--- a/src/Microsoft.Restier.Core/ApiBase.cs
+++ b/src/Microsoft.Restier.Core/ApiBase.cs
@@ -114,6 +114,7 @@ namespace Microsoft.Restier.Core
             {
                 ApiConfiguratorAttribute.ApplyDisposal(
                     this.GetType(), this, this.apiContext);
+                this.apiContext.DisposeScope();
             }
 
             this.Dispose(true);

--- a/src/Microsoft.Restier.Core/ApiConfiguration.cs
+++ b/src/Microsoft.Restier.Core/ApiConfiguration.cs
@@ -4,12 +4,17 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.OData.Edm;
 using Microsoft.Restier.Core.Properties;
 using Microsoft.Restier.Core.Query;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Extensions;
 
 namespace Microsoft.Restier.Core
 {
+    public delegate T HookHandlerContributor<T>(IServiceProvider sp, Func<T> next) where T : IHookHandler;
+
     /// <summary>
     /// Represents a configuration that defines an API.
     /// </summary>
@@ -35,15 +40,38 @@ namespace Microsoft.Restier.Core
     /// </remarks>
     public class ApiConfiguration : PropertyBag
     {
-        private readonly IDictionary<Type, IHookHandler> hookHandlers =
-            new ConcurrentDictionary<Type, IHookHandler>();
+        private IServiceCollection services;
+
+        private IServiceProvider serviceProvider;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiConfiguration" /> class.
         /// </summary>
-        public ApiConfiguration()
+        public ApiConfiguration() : this(null)
         {
+        }
+
+        [CLSCompliant(false)]
+        public ApiConfiguration(IServiceCollection services)
+        {
+            if (services == null)
+            {
+                services = new ServiceCollection();
+            }
+
+            this.services = services;
             this.AddDefaultHookHandlers();
+        }
+
+        public IServiceProvider ServiceProvider
+        {
+            get { return serviceProvider; }
+        }
+
+        [CLSCompliant(false)]
+        public IServiceCollection Services
+        {
+            get { return services; }
         }
 
         /// <summary>
@@ -54,12 +82,85 @@ namespace Microsoft.Restier.Core
         internal IEdmModel Model { get; set; }
 
         /// <summary>
+        /// Override this to use your favorite DI container, as long as it has an IServiceProvider wrapper.
+        /// </summary>
+        /// <returns></returns>
+        protected virtual IServiceProvider BuildServiceProvider()
+        {
+            return Services.BuildServiceProvider();
+        }
+
+        /// <summary>
         /// Ensures this API configuration has been committed.
         /// </summary>
         public void EnsureCommitted()
         {
+            if (this.IsCommitted) return;
+
+            this.serviceProvider = BuildServiceProvider();
+            this.services = null;
+
             this.IsCommitted = true;
         }
+
+        private class LegacyHookHandler<T> where T : class, IHookHandler
+        {
+            public LegacyHookHandler(T instance)
+            {
+                Instance = instance;
+            }
+
+            public T Instance { get; private set; }
+        }
+
+        private static class HookHandlerType<T> where T : class, IHookHandler
+        {
+            public readonly static Func<IServiceProvider, T> DefaultFactory = sp =>
+            {
+                var instances = sp.GetServices<HookHandlerContributor<T>>().Reverse();
+
+                using (var e = instances.GetEnumerator())
+                {
+                    Func<T> next = null;
+                    next = () =>
+                    {
+                        if (e.MoveNext())
+                        {
+                            return e.Current(sp, next);
+                        }
+
+                        return null;
+                    };
+
+                    return next();
+                }
+            };
+
+            public static T BuildLegacyHandlers(IServiceProvider sp)
+            {
+                var instances = sp.GetServices<LegacyHookHandler<T>>().Reverse();
+
+                using (var e = instances.GetEnumerator())
+                {
+                    if (!e.MoveNext())
+                    {
+                        return null;
+                    }
+
+                    T first = e.Current.Instance;
+                    T current = first;
+                    while (e.MoveNext())
+                    {
+                        var delegateHandler = current as IDelegateHookHandler<T>;
+                        if (delegateHandler == null) break;
+
+                        delegateHandler.InnerHandler = current = e.Current.Instance;
+                    }
+
+                    return first;
+                }
+            }
+        };
 
         #region HookHandler
         /// <summary>
@@ -82,13 +183,83 @@ namespace Microsoft.Restier.Core
                 throw new InvalidOperationException(Resources.ShouldBeInterfaceType);
             }
 
-            var delegateHandler = handler as IDelegateHookHandler<T>;
-            if (delegateHandler != null)
+            // Since legacy hook handlers are registered with instance, they must have singleton lifetime.
+            // And so a singleton HookHandlerContributor is registered for each hook handler type, and it
+            // will cache the legacy handler chain once built.
+            if (!this.services.Any(sd => sd.ServiceType == typeof(LegacyHookHandler<T>)))
             {
-                delegateHandler.InnerHandler = this.GetHookHandler<T>();
+                T cached = null;
+                this.services.AddInstance<HookHandlerContributor<T>>((sp, next) =>
+                {
+                    return cached ?? (cached = HookHandlerType<T>.BuildLegacyHandlers(sp));
+                });
+
+                // Hook handlers have singleton lifetime by default, call Make... to change.
+                this.services.TryAddSingleton(typeof(T), HookHandlerType<T>.DefaultFactory);
             }
 
-            this.hookHandlers[typeof(T)] = handler;
+            this.services.AddInstance(new LegacyHookHandler<T>(handler));
+
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a hook handler contributor, which has a chance to chain previously registered hook handler instances.
+        /// </summary>
+        /// <typeparam name="T">The hook handler interface.</typeparam>
+        /// <param name="contributor">An instance of <see cref="HookHandlerContributor{T}"/>.</param>
+        /// <returns>Current <see cref="ApiConfiguration"/></returns>
+        public ApiConfiguration AddHookHandler<T>(HookHandlerContributor<T> contributor) where T : class, IHookHandler
+        {
+            Ensure.NotNull(contributor, nameof(contributor));
+
+            if (this.IsCommitted)
+            {
+                throw new InvalidOperationException(Resources.ApiConfigurationIsCommitted);
+            }
+
+            if (!typeof(T).IsInterface)
+            {
+                throw new InvalidOperationException(Resources.ShouldBeInterfaceType);
+            }
+
+            // Hook handlers have singleton lifetime by default, call Make... to change.
+            this.services.TryAddSingleton(typeof(T), HookHandlerType<T>.DefaultFactory);
+            this.services.AddInstance(contributor);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Call this to make singleton lifetime of a hook handler.
+        /// </summary>
+        /// <typeparam name="T">The hook handler interface.</typeparam>
+        /// <returns>Current <see cref="ApiConfiguration"/></returns>
+        public ApiConfiguration MakeSingleton<T>() where T : class, IHookHandler
+        {
+            this.services.AddSingleton<T>(HookHandlerType<T>.DefaultFactory);
+            return this;
+        }
+
+        /// <summary>
+        /// Call this to make scoped lifetime of a hook handler.
+        /// </summary>
+        /// <typeparam name="T">The hook handler interface.</typeparam>
+        /// <returns>Current <see cref="ApiConfiguration"/></returns>
+        public ApiConfiguration MakeScoped<T>() where T : class, IHookHandler
+        {
+            this.services.AddScoped<T>(HookHandlerType<T>.DefaultFactory);
+            return this;
+        }
+
+        /// <summary>
+        /// Call this to make transient lifetime of a hook handler.
+        /// </summary>
+        /// <typeparam name="T">The hook handler interface.</typeparam>
+        /// <returns>Current <see cref="ApiConfiguration"/></returns>
+        public ApiConfiguration MakeTransient<T>() where T : class, IHookHandler
+        {
+            this.services.AddTransient<T>(HookHandlerType<T>.DefaultFactory);
             return this;
         }
 
@@ -99,9 +270,7 @@ namespace Microsoft.Restier.Core
         /// <returns>The hook handler instance.</returns>
         public T GetHookHandler<T>() where T : class, IHookHandler
         {
-            IHookHandler value;
-            this.hookHandlers.TryGetValue(typeof(T), out value);
-            return value as T;
+            return this.serviceProvider.GetService<T>();
         }
         #endregion
 

--- a/src/Microsoft.Restier.Core/ApiContext.cs
+++ b/src/Microsoft.Restier.Core/ApiContext.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.Restier.Core.Properties;
+using Microsoft.Framework.DependencyInjection;
 
 namespace Microsoft.Restier.Core
 {
@@ -16,6 +17,8 @@ namespace Microsoft.Restier.Core
     /// </remarks>
     public class ApiContext : PropertyBag
     {
+        IServiceScope contextScope;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiContext" /> class.
         /// </summary>
@@ -31,11 +34,32 @@ namespace Microsoft.Restier.Core
             }
 
             this.Configuration = configuration;
+            this.contextScope = configuration.ServiceProvider.GetRequiredService<IApiScopeFactory>().CreateApiScope();
         }
 
         /// <summary>
         /// Gets the API configuration.
         /// </summary>
         public ApiConfiguration Configuration { get; private set; }
+
+        public IServiceProvider ServiceProvider
+        {
+            get { return this.contextScope.ServiceProvider; }
+        }
+
+        /// <summary>
+        /// Gets a service instance.
+        /// </summary>
+        /// <typeparam name="T">The service type.</typeparam>
+        /// <returns>The service instance.</returns>
+        public T GetApiService<T>() where T : class
+        {
+            return this.ServiceProvider.GetService<T>();
+        }
+
+        internal void DisposeScope()
+        {
+            this.contextScope.Dispose();
+        }
     }
 }

--- a/src/Microsoft.Restier.Core/IApiScopeFactory.cs
+++ b/src/Microsoft.Restier.Core/IApiScopeFactory.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Framework.DependencyInjection;
+
+namespace Microsoft.Restier.Core
+{
+    [CLSCompliant(false)]
+    public interface IApiScopeFactory
+    {
+        IServiceScope CreateApiScope();
+    }
+}

--- a/src/Microsoft.Restier.Core/InvocationContext.cs
+++ b/src/Microsoft.Restier.Core/InvocationContext.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Restier.Core
         /// </remarks>
         public T GetHookHandler<T>() where T : class, IHookHandler
         {
-            return this.ApiContext.Configuration.GetHookHandler<T>();
+            return this.ApiContext.GetApiService<T>();
         }
     }
 }

--- a/src/Microsoft.Restier.Core/Microsoft.Restier.Core.csproj
+++ b/src/Microsoft.Restier.Core/Microsoft.Restier.Core.csproj
@@ -53,6 +53,7 @@
     <Compile Include="..\Shared\TypeExtensions.cs">
       <Link>Shared\TypeExtensions.cs</Link>
     </Compile>
+    <Compile Include="IApiScopeFactory.cs" />
     <Compile Include="Model\FunctionAttribute.cs" />
     <Compile Include="Model\ActionAttribute.cs" />
     <Compile Include="Conventions\ConventionBasedChangeSetAuthorizer.cs" />

--- a/src/Microsoft.Restier.Core/Microsoft.Restier.Core.csproj
+++ b/src/Microsoft.Restier.Core/Microsoft.Restier.Core.csproj
@@ -14,6 +14,14 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Framework.DependencyInjection, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Framework.DependencyInjection.1.0.0-beta8\lib\net45\Microsoft.Framework.DependencyInjection.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Framework.DependencyInjection.Abstractions, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Framework.DependencyInjection.Abstractions.1.0.0-beta8\lib\net45\Microsoft.Framework.DependencyInjection.Abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.OData.Edm, Version=6.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.OData.Edm.6.13.0\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Edm.dll</HintPath>
       <Private>True</Private>

--- a/src/Microsoft.Restier.Core/packages.config
+++ b/src/Microsoft.Restier.Core/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Framework.DependencyInjection" version="1.0.0-beta8" targetFramework="net45" />
+  <package id="Microsoft.Framework.DependencyInjection.Abstractions" version="1.0.0-beta8" targetFramework="net45" />
   <package id="Microsoft.OData.Edm" version="6.13.0" targetFramework="net45" />
 </packages>

--- a/test/Microsoft.Restier.Core.Tests/ApiConfiguration.Tests.cs
+++ b/test/Microsoft.Restier.Core.Tests/ApiConfiguration.Tests.cs
@@ -97,6 +97,7 @@ namespace Microsoft.Restier.Core.Tests
             var configuration = new ApiConfiguration()
                 .AddHookHandler<IHookB>(q1)
                 .AddHookHandler<IHookB>(q2);
+            configuration.EnsureCommitted();
 
             var handler = configuration.GetHookHandler<IHookB>();
             Assert.Equal("q2Pre_q1Pre_q1Post_q2Post_", handler.GetStr());


### PR DESCRIPTION
…want you to review then decide whether it's acceptable.

As you know I was in a project which utilized RESTier as a hub to integrate all its feature logic. And since we played with dynamic types generated at runtime, it was very hard (if not impossible) to work at WebApi level. So it made me believe that a powerful DI framework in RESTier will have its unique value.
Of course you guys will make the decision, and I'll respect either way.

This is to incorporate Micorsoft DI framework into RESTier, to replace current Dictionary<,> based service registration.
Pros:
* Powerful - lifetime control, various ways to register a service, service composition etc. All the features that DI framework supports.
* Backward compatible at API level. Existing hook handlers keep working as expected.
* Enable injecting any type of services, i.e. other than IHookHandler.
* Scope capable, although not implemented yet in this change, but it would be quite simple.

Cons:
* Dependency on DI libraries. Although it's possible to use any other DI container, we have to add default DI implementation as reference.
* Minor perf hit on service registration, which IMO has no real impact.
* Can't resolve hook handlers before EnsureCommitted().