### PR TITLE
Microsoft.FX.DI integration [Option 1]

### DIFF
--- a/src/GlobalSuppressions.cs
+++ b/src/GlobalSuppressions.cs
@@ -21,6 +21,7 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Microsoft.Usage", "CA2243:AttributeStringLiteralsShouldParseCorrectly", Justification = "AssemblyInformationalVersion could be string.")]
 
 #region CA1004 Generic method with type parameter
+[assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.Core.ApiBuilderExtensions.#ChainPrevious`2(Microsoft.Restier.Core.ApiBuilder)")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.Core.ApiBuilderExtensions.#HasHookHandler`1(Microsoft.Restier.Core.ApiBuilder)")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.Core.ApiBuilderExtensions.#MakeSingleton`1(Microsoft.Restier.Core.ApiBuilder)")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.Core.ApiBuilderExtensions.#MakeScoped`1(Microsoft.Restier.Core.ApiBuilder)")]

--- a/src/GlobalSuppressions.cs
+++ b/src/GlobalSuppressions.cs
@@ -21,6 +21,10 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Microsoft.Usage", "CA2243:AttributeStringLiteralsShouldParseCorrectly", Justification = "AssemblyInformationalVersion could be string.")]
 
 #region CA1004 Generic method with type parameter
+[assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.Core.ApiBuilderExtensions.#HasHookHandler`1(Microsoft.Restier.Core.ApiBuilder)")]
+[assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.Core.ApiBuilderExtensions.#MakeSingleton`1(Microsoft.Restier.Core.ApiBuilder)")]
+[assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.Core.ApiBuilderExtensions.#MakeScoped`1(Microsoft.Restier.Core.ApiBuilder)")]
+[assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.Core.ApiBuilderExtensions.#MakeTransient`1(Microsoft.Restier.Core.ApiBuilder)")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.Core.Query.IQueryExecutor.#ExecuteSingleAsync`1(Microsoft.Restier.Core.Query.QueryContext,System.Linq.IQueryable,System.Linq.Expressions.Expression,System.Threading.CancellationToken)")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.WebApi.HttpConfigurationExtensions.#MapRestierRoute`1(System.Web.Http.HttpConfiguration,System.String,System.String,System.Func`1<Microsoft.Restier.Core.IApi>,Microsoft.Restier.WebApi.Batch.RestierBatchHandler)")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.WebApi.HttpConfigurationExtensions.#MapRestierRoute`1(System.Web.Http.HttpConfiguration,System.String,System.String,Microsoft.Restier.WebApi.Batch.RestierBatchHandler)")]
@@ -147,6 +151,7 @@ using System.Diagnostics.CodeAnalysis;
 #endregion
 
 #region CA2000 Dispose objects
+[assembly: SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Scope = "member", Target = "Microsoft.Restier.Core.ApiBuilderExtensions+SharedApiScopeFactory.#CreateApiScope()")]
 [assembly: SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Scope = "member", Target = "Microsoft.Restier.WebApi.RestierController`1.#GetSource(System.Web.OData.Routing.ODataPath,Microsoft.OData.Edm.IEdmEntityType&)")]
 [assembly: SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Scope = "member", Target = "Microsoft.Restier.WebApi.RestierController`1.#CreateQueryResponse(System.Linq.IQueryable,Microsoft.OData.Edm.IEdmType)")]
 [assembly: SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Scope = "member", Target = "Microsoft.Restier.WebApi.RestierController.#CreateQueryResponse(System.Linq.IQueryable,Microsoft.OData.Edm.IEdmType)")]

--- a/src/Microsoft.Restier.Core/Api.cs
+++ b/src/Microsoft.Restier.Core/Api.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Restier.Core
             var config = context.Configuration;
             if (config.Model == null)
             {
-                var builder = context.Configuration.GetHookHandler<IModelBuilder>();
+                var builder = context.GetApiService<IModelBuilder>();
                 if (builder != null)
                 {
                     config.Model = await builder.GetModelAsync(new InvocationContext(context), cancellationToken);
@@ -631,7 +631,7 @@ namespace Microsoft.Restier.Core
         {
             Type elementType = null;
 
-            var mapper = context.Configuration.GetHookHandler<IModelMapper>();
+            var mapper = context.GetApiService<IModelMapper>();
             if (mapper != null)
             {
                 if (namespaceName == null)

--- a/src/Microsoft.Restier.Core/ApiBase.cs
+++ b/src/Microsoft.Restier.Core/ApiBase.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Restier.Core
                     ApiConfiguration configuration;
                     if (!Configurations.TryGetValue(apiType, out configuration))
                     {
-                        var builder = this.ConfigureApiBuilder(new ApiBuilder());
+                        var builder = this.ConfigureApi(new ApiBuilder());
                         EnableConventions(builder, apiType);
                         ApiConfiguratorAttribute.ApplyApiBuilder(apiType, builder);
                         builder.TryUseSharedApiScope(); // TODO: Maybe default to context scope?
@@ -130,8 +130,7 @@ namespace Microsoft.Restier.Core
         /// The <see cref="ApiBuilder"/> with which to create an <see cref="ApiConfiguration"/>.
         /// </param>
         /// <returns>The <see cref="ApiBuilder"/>.</returns>
-        [CLSCompliant(false)]
-        protected virtual ApiBuilder ConfigureApiBuilder(ApiBuilder builder)
+        protected virtual ApiBuilder ConfigureApi(ApiBuilder builder)
         {
             return builder;
         }
@@ -145,7 +144,6 @@ namespace Microsoft.Restier.Core
         /// <returns>
         /// An <see cref="ApiConfiguration"/> with which to create the API configuration for this API.
         /// </returns>
-        [CLSCompliant(false)]
         protected virtual ApiConfiguration CreateApiConfiguration(ApiBuilder builder)
         {
             return builder.Build();

--- a/src/Microsoft.Restier.Core/ApiBuilder.cs
+++ b/src/Microsoft.Restier.Core/ApiBuilder.cs
@@ -25,7 +25,6 @@ namespace Microsoft.Restier.Core
     /// <summary>
     /// Builder object to create an <see cref="ApiConfiguration"/>
     /// </summary>
-    [CLSCompliant(false)]
     public sealed class ApiBuilder
     {
         /// <summary>
@@ -40,6 +39,7 @@ namespace Microsoft.Restier.Core
         /// Initializes a new instance of the <see cref="ApiBuilder"/> class.
         /// </summary>
         /// <param name="services">A service collection.</param>
+        [CLSCompliant(false)]
         public ApiBuilder(IServiceCollection services)
         {
             Services = services ?? new ServiceCollection();
@@ -52,6 +52,7 @@ namespace Microsoft.Restier.Core
         /// <summary>
         /// Gets the service collection containing service registration.
         /// </summary>
+        [CLSCompliant(false)]
         public IServiceCollection Services
         {
             get; private set;

--- a/src/Microsoft.Restier.Core/ApiBuilder.cs
+++ b/src/Microsoft.Restier.Core/ApiBuilder.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Restier.Core.Query;
+
+namespace Microsoft.Restier.Core
+{
+    /// <summary>
+    /// A delegate which participate in service creation.
+    /// All registered contributors form a chain, and the last registered will be called first.
+    /// </summary>
+    /// <typeparam name="T">The service type.</typeparam>
+    /// <param name="serviceProvider">
+    /// The <see cref="IServiceProvider"/> to which this contributor call is registered.
+    /// </param>
+    /// <param name="next">
+    /// Return the result of the previous contributor on the chain.
+    /// </param>
+    /// <returns>A service instance of <typeparamref name="T"/>.</returns>
+    public delegate T ApiServiceContributor<T>(IServiceProvider serviceProvider, Func<T> next) where T : class;
+
+    /// <summary>
+    /// Builder object to create an <see cref="ApiConfiguration"/>
+    /// </summary>
+    [CLSCompliant(false)]
+    public sealed class ApiBuilder
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiBuilder"/> class.
+        /// </summary>
+        public ApiBuilder()
+            : this(null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiBuilder"/> class.
+        /// </summary>
+        /// <param name="services">A service collection.</param>
+        public ApiBuilder(IServiceCollection services)
+        {
+            Services = services ?? new ServiceCollection();
+            if (!this.HasHookHandler<IQueryExecutor>())
+            {
+                this.AddHookHandler<IQueryExecutor>(DefaultQueryExecutor.Instance);
+            }
+        }
+
+        /// <summary>
+        /// Gets the service collection containing service registration.
+        /// </summary>
+        public IServiceCollection Services
+        {
+            get; private set;
+        }
+    }
+}

--- a/src/Microsoft.Restier.Core/ApiBuilderExtensions.cs
+++ b/src/Microsoft.Restier.Core/ApiBuilderExtensions.cs
@@ -1,0 +1,377 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Extensions;
+using Microsoft.Restier.Core.Properties;
+
+namespace Microsoft.Restier.Core
+{
+    /// <summary>
+    /// Contains extension methods of <see cref="ApiBuilder"/>.
+    /// </summary>
+    [CLSCompliant(false)]
+    public static class ApiBuilderExtensions
+    {
+        /// <summary>
+        /// Make the built <see cref="ApiConfiguration"/> to create <see cref="ApiContext"/> with its own instance
+        /// of <see cref="IServiceProvider"/>.
+        /// </summary>
+        /// <param name="obj">The <see cref="ApiBuilder"/>.</param>
+        /// <returns>Current <see cref="ApiBuilder"/></returns>
+        public static ApiBuilder UseSharedApiScope(this ApiBuilder obj)
+        {
+            obj.Services.AddSingleton<IApiScopeFactory, SharedApiScopeFactory>();
+            return obj;
+        }
+
+        /// <summary>
+        /// Make the built <see cref="ApiConfiguration"/> to create <see cref="ApiContext"/> with a scoped
+        /// <see cref="IServiceProvider"/>.
+        /// </summary>
+        /// <param name="obj">The <see cref="ApiBuilder"/>.</param>
+        /// <returns>Current <see cref="ApiBuilder"/></returns>
+        public static ApiBuilder UseContextApiScope(this ApiBuilder obj)
+        {
+            obj.Services.AddSingleton<IApiScopeFactory, ContextApiScopeFactory>();
+            return obj;
+        }
+
+        /// <summary>
+        /// If service scope is not yet configured, make the built <see cref="ApiConfiguration"/> to create
+        /// <see cref="ApiContext"/> with its own instance of <see cref="IServiceProvider"/>.
+        /// </summary>
+        /// <param name="obj">The <see cref="ApiBuilder"/>.</param>
+        /// <returns>Current <see cref="ApiBuilder"/></returns>
+        public static ApiBuilder TryUseSharedApiScope(this ApiBuilder obj)
+        {
+            obj.Services.TryAddSingleton<IApiScopeFactory, SharedApiScopeFactory>();
+            return obj;
+        }
+
+        /// <summary>
+        /// If service scope is not yet configured, make the built <see cref="ApiConfiguration"/> to create
+        /// <see cref="ApiContext"/> with a scoped <see cref="IServiceProvider"/>.
+        /// </summary>
+        /// <param name="obj">The <see cref="ApiBuilder"/>.</param>
+        /// <returns>Current <see cref="ApiBuilder"/></returns>
+        public static ApiBuilder TryUseContextApiScope(this ApiBuilder obj)
+        {
+            obj.Services.TryAddSingleton<IApiScopeFactory, ContextApiScopeFactory>();
+            return obj;
+        }
+
+        /// <summary>
+        /// Return true if the <see cref="ApiBuilder"/> has any <typeparamref name="T"/> service registered.
+        /// </summary>
+        /// <typeparam name="T">The hook handler interface.</typeparam>
+        /// <param name="obj">The <see cref="ApiBuilder"/>.</param>
+        /// <returns>
+        /// True if the hook handler is registered.
+        /// </returns>
+        public static bool HasHookHandler<T>(this ApiBuilder obj) where T : class, IHookHandler
+        {
+            return obj.Services.Any(sd => sd.ServiceType == typeof(LegacyHookHandler<T>));
+        }
+
+        /// <summary>
+        /// Adds a hook handler instance.
+        /// </summary>
+        /// <typeparam name="T">The hook handler interface.</typeparam>
+        /// <param name="obj">The <see cref="ApiBuilder"/>.</param>
+        /// <param name="handler">An instance of hook handler for <typeparamref name="T"/>.</param>
+        /// <returns>Current <see cref="ApiBuilder"/></returns>
+        public static ApiBuilder AddHookHandler<T>(this ApiBuilder obj, T handler) where T : class, IHookHandler
+        {
+            Ensure.NotNull(handler, "handler");
+
+            if (!typeof(T).IsInterface)
+            {
+                throw new InvalidOperationException(Resources.ShouldBeInterfaceType);
+            }
+
+            // Since legacy hook handlers are registered with instance, they must have singleton lifetime.
+            // And so a singleton HookHandlerContributor is registered for each hook handler type, and it
+            // will cache the legacy handler chain once built.
+            if (!obj.HasHookHandler<T>())
+            {
+                T cached = null;
+                obj.Services.AddInstance<ApiServiceContributor<T>>((sp, next) =>
+                {
+                    return cached ?? (cached = HookHandlerType<T>.BuildLegacyHandlers(sp, next));
+                });
+
+                // Hook handlers have singleton lifetime by default, call Make... to change.
+                obj.Services.TryAddSingleton(typeof(T), ChainedService<T>.DefaultFactory);
+            }
+
+            obj.Services.AddInstance(new LegacyHookHandler<T>(handler));
+            return obj;
+        }
+
+        /// <summary>
+        /// Adds a service contributor, which has a chance to chain previously registered service instances.
+        /// </summary>
+        /// <typeparam name="T">The service type.</typeparam>
+        /// <param name="obj">The <see cref="ApiBuilder"/>.</param>
+        /// <param name="instance">An instance of <typeparamref name="T"/>.</param>
+        /// <returns>Current <see cref="ApiBuilder"/></returns>
+        public static ApiBuilder AddInstance<T>(this ApiBuilder obj, T instance) where T : class
+        {
+            obj.Services.AddInstance<T>(instance);
+            return obj;
+        }
+
+        /// <summary>
+        /// Adds a service contributor, which has a chance to chain previously registered service instances.
+        /// </summary>
+        /// <typeparam name="T">The service type.</typeparam>
+        /// <param name="obj">The <see cref="ApiBuilder"/>.</param>
+        /// <param name="contributor">An instance of <see cref="ApiServiceContributor{T}"/>.</param>
+        /// <returns>Current <see cref="ApiBuilder"/></returns>
+        public static ApiBuilder AddContributor<T>(this ApiBuilder obj, ApiServiceContributor<T> contributor)
+            where T : class
+        {
+            Ensure.NotNull(contributor, nameof(contributor));
+
+            // Services have singleton lifetime by default, call Make... to change.
+            obj.Services.TryAddSingleton(typeof(T), ChainedService<T>.DefaultFactory);
+            obj.Services.AddInstance(contributor);
+
+            return obj;
+        }
+
+        /// <summary>
+        /// Adds a service contributor, which has a chance to chain previously registered service instances.
+        /// </summary>
+        /// <typeparam name="T">The service type.</typeparam>
+        /// <param name="obj">The <see cref="ApiBuilder"/>.</param>
+        /// <param name="factory">
+        /// A factory method to create a new instance of service T, wrapping previous instance."/>.
+        /// </param>
+        /// <returns>Current <see cref="ApiBuilder"/></returns>
+        public static ApiBuilder ChainPrevious<T>(this ApiBuilder obj, Func<IServiceProvider, T, T> factory)
+            where T : class
+        {
+            Ensure.NotNull(factory, nameof(factory));
+            return obj.AddContributor<T>((sp, next) => factory(sp, next()));
+        }
+
+        /// <summary>
+        /// Adds a service contributor, which has a chance to chain previously registered service instances.
+        /// </summary>
+        /// <typeparam name="T">The service type.</typeparam>
+        /// <param name="obj">The <see cref="ApiBuilder"/>.</param>
+        /// <param name="factory">
+        /// A factory method to create a new instance of service T, wrapping previous instance."/>.
+        /// </param>
+        /// <returns>Current <see cref="ApiBuilder"/></returns>
+        public static ApiBuilder ChainPrevious<T>(this ApiBuilder obj, Func<T, T> factory) where T : class
+        {
+            Ensure.NotNull(factory, nameof(factory));
+            return obj.AddContributor<T>((sp, next) => factory(next()));
+        }
+
+        /// <summary>
+        /// Call this to make singleton lifetime of a service.
+        /// </summary>
+        /// <typeparam name="T">The service type.</typeparam>
+        /// <param name="obj">The <see cref="ApiBuilder"/>.</param>
+        /// <returns>Current <see cref="ApiBuilder"/></returns>
+        public static ApiBuilder MakeSingleton<T>(this ApiBuilder obj) where T : class
+        {
+            obj.Services.AddSingleton<T>(ChainedService<T>.DefaultFactory);
+            return obj;
+        }
+
+        /// <summary>
+        /// Call this to make scoped lifetime of a service.
+        /// </summary>
+        /// <typeparam name="T">The service type.</typeparam>
+        /// <param name="obj">The <see cref="ApiBuilder"/>.</param>
+        /// <returns>Current <see cref="ApiBuilder"/></returns>
+        public static ApiBuilder MakeScoped<T>(this ApiBuilder obj) where T : class
+        {
+            obj.Services.AddScoped<T>(ChainedService<T>.DefaultFactory);
+            return obj;
+        }
+
+        /// <summary>
+        /// Call this to make transient lifetime of a service.
+        /// </summary>
+        /// <typeparam name="T">The service type.</typeparam>
+        /// <param name="obj">The <see cref="ApiBuilder"/>.</param>
+        /// <returns>Current <see cref="ApiBuilder"/></returns>
+        public static ApiBuilder MakeTransient<T>(this ApiBuilder obj) where T : class
+        {
+            obj.Services.AddTransient<T>(ChainedService<T>.DefaultFactory);
+            return obj;
+        }
+
+        /// <summary>
+        /// Build the <see cref="ApiConfiguration"/>
+        /// </summary>
+        /// <param name="obj">The <see cref="ApiBuilder"/>.</param>
+        /// <param name="serviceProviderFactory">
+        /// An optional factory to create an <see cref="IServiceProvider"/>.
+        /// Use this to inject your favorite DI container.
+        /// </param>
+        /// <returns>The built <see cref="ApiConfiguration"/></returns>
+        public static ApiConfiguration Build(
+            this ApiBuilder obj,
+            Func<ApiBuilder, IServiceProvider> serviceProviderFactory = null)
+        {
+            obj.Services.TryAddSingleton<ApiConfiguration>();
+            obj.TryUseContextApiScope();
+
+            var serviceProvider = serviceProviderFactory != null ?
+                serviceProviderFactory(obj) : obj.Services.BuildServiceProvider();
+            return serviceProvider.GetService<ApiConfiguration>();
+        }
+
+        /// <summary>
+        /// Call this to build a service chain explicitly.
+        /// Typically you just resolve the service with <see cref="IServiceProvider.GetService(Type)"/>, but
+        /// in case you register your own factory of <typeparamref name="T"/>, you may need this to get the
+        /// service chain registered with <see cref="ApiBuilder"/>.
+        /// </summary>
+        /// <typeparam name="T">The service type.</typeparam>
+        /// <param name="obj">The <see cref="ApiBuilder"/>.</param>
+        /// <returns>The service instance built.</returns>
+        /// <example>
+        /// <code>
+        /// services.AddScoped &lt; ISomeService &gt;(sp =>
+        ///     new SomeService(sp.BuildApiServiceChain &lt; ISomeService &gt;()));
+        /// </code>
+        /// </example>
+        public static T BuildApiServiceChain<T>(this IServiceProvider obj) where T : class
+        {
+            return ChainedService<T>.DefaultFactory(obj);
+        }
+
+        private class SharedApiScopeFactory : IApiScopeFactory
+        {
+            public SharedApiScopeFactory(IServiceProvider serviceProvider)
+            {
+                this.ServiceProvider = serviceProvider;
+            }
+
+            public IServiceProvider ServiceProvider
+            {
+                get; private set;
+            }
+
+            public IServiceScope CreateApiScope()
+            {
+                return new ServiceScope()
+                {
+                    ServiceProvider = this.ServiceProvider,
+                };
+            }
+
+            private class ServiceScope : IServiceScope
+            {
+                public IServiceProvider ServiceProvider
+                {
+                    get; set;
+                }
+
+                public void Dispose()
+                {
+                    this.ServiceProvider = null;
+                }
+            }
+        }
+
+        private class ContextApiScopeFactory : IApiScopeFactory
+        {
+            public ContextApiScopeFactory(IServiceScopeFactory factory)
+            {
+                this.Factory = factory;
+            }
+
+            public IServiceScopeFactory Factory
+            {
+                get; private set;
+            }
+
+            public IServiceScope CreateApiScope()
+            {
+                return this.Factory.CreateScope();
+            }
+        }
+    }
+
+    internal static class ChainedService<T> where T : class
+    {
+        public static readonly Func<IServiceProvider, T> DefaultFactory = sp =>
+        {
+            var instances = sp.GetServices<ApiServiceContributor<T>>().Reverse();
+
+            using (var e = instances.GetEnumerator())
+            {
+                Func<T> next = null;
+                next = () =>
+                {
+                    if (e.MoveNext())
+                    {
+                        return e.Current(sp, next);
+                    }
+
+                    return null;
+                };
+
+                return next();
+            }
+        };
+    }
+
+    internal static class HookHandlerType<T> where T : class, IHookHandler
+    {
+        public static T BuildLegacyHandlers(IServiceProvider sp, Func<T> next)
+        {
+            var instances = sp.GetServices<LegacyHookHandler<T>>().Reverse();
+
+            using (var e = instances.GetEnumerator())
+            {
+                if (!e.MoveNext())
+                {
+                    return null;
+                }
+
+                T first = e.Current.Instance;
+                T current = first;
+                while (e.MoveNext())
+                {
+                    var delegateHandler = current as IDelegateHookHandler<T>;
+                    if (delegateHandler == null)
+                    {
+                        return first;
+                    }
+
+                    delegateHandler.InnerHandler = current = e.Current.Instance;
+                }
+
+                var finalDelegate = current as IDelegateHookHandler<T>;
+                if (finalDelegate != null)
+                {
+                    finalDelegate.InnerHandler = next();
+                }
+
+                return first;
+            }
+        }
+    }
+
+    internal class LegacyHookHandler<T> where T : class, IHookHandler
+    {
+        public LegacyHookHandler(T instance)
+        {
+            Instance = instance;
+        }
+
+        public T Instance { get; private set; }
+    }
+}

--- a/src/Microsoft.Restier.Core/ApiBuilderExtensions.cs
+++ b/src/Microsoft.Restier.Core/ApiBuilderExtensions.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Restier.Core
     /// <summary>
     /// Contains extension methods of <see cref="ApiBuilder"/>.
     /// </summary>
-    [CLSCompliant(false)]
     public static class ApiBuilderExtensions
     {
         /// <summary>

--- a/src/Microsoft.Restier.Core/ApiConfiguration.cs
+++ b/src/Microsoft.Restier.Core/ApiConfiguration.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.OData.Edm;
+using Microsoft.Restier.Core.Properties;
 
 namespace Microsoft.Restier.Core
 {
@@ -58,7 +59,7 @@ namespace Microsoft.Restier.Core
         /// </summary>
         public bool IsCommitted
         {
-            get { return true; }
+            get { return serviceProvider != null; }
         }
 
         internal IEdmModel Model { get; set; }
@@ -68,6 +69,10 @@ namespace Microsoft.Restier.Core
         /// </summary>
         public void EnsureCommitted()
         {
+            if (!IsCommitted)
+            {
+                throw new ArgumentException(Resources.ApiConfigurationShouldBeCommitted);
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.Restier.Core/ApiConfiguratorAttribute.cs
+++ b/src/Microsoft.Restier.Core/ApiConfiguratorAttribute.cs
@@ -23,6 +23,36 @@ namespace Microsoft.Restier.Core
 
         /// <summary>
         /// Applies configuration from any API configurator attributes
+        /// specified on an API type to an API builder.
+        /// </summary>
+        /// <param name="type">
+        /// An API type.
+        /// </param>
+        /// <param name="builder">
+        /// An API builder.
+        /// </param>
+        [CLSCompliant(false)]
+        public static void ApplyApiBuilder(
+            Type type, ApiBuilder builder)
+        {
+            Ensure.NotNull(type, "type");
+            Ensure.NotNull(builder, "builder");
+            if (type.BaseType != null)
+            {
+                ApiConfiguratorAttribute.ApplyApiBuilder(
+                    type.BaseType, builder);
+            }
+
+            var attributes = type.GetCustomAttributes(
+                typeof(ApiConfiguratorAttribute), false);
+            foreach (ApiConfiguratorAttribute attribute in attributes)
+            {
+                attribute.ConfigureBuilder(builder, type);
+            }
+        }
+
+        /// <summary>
+        /// Applies configuration from any API configurator attributes
         /// specified on an API type to an API configuration.
         /// </summary>
         /// <param name="type">
@@ -112,6 +142,22 @@ namespace Microsoft.Restier.Core
                 ApiConfiguratorAttribute.ApplyDisposal(
                     type.BaseType, instance, context);
             }
+        }
+
+        /// <summary>
+        /// Configures an API builder.
+        /// </summary>
+        /// <param name="builder">
+        /// An API builder.
+        /// </param>
+        /// <param name="type">
+        /// The API type on which this attribute was placed.
+        /// </param>
+        [CLSCompliant(false)]
+        public virtual void ConfigureBuilder(
+            ApiBuilder builder,
+            Type type)
+        {
         }
 
         /// <summary>

--- a/src/Microsoft.Restier.Core/ApiConfiguratorAttribute.cs
+++ b/src/Microsoft.Restier.Core/ApiConfiguratorAttribute.cs
@@ -31,7 +31,6 @@ namespace Microsoft.Restier.Core
         /// <param name="builder">
         /// An API builder.
         /// </param>
-        [CLSCompliant(false)]
         public static void ApplyApiBuilder(
             Type type, ApiBuilder builder)
         {
@@ -47,7 +46,7 @@ namespace Microsoft.Restier.Core
                 typeof(ApiConfiguratorAttribute), false);
             foreach (ApiConfiguratorAttribute attribute in attributes)
             {
-                attribute.ConfigureBuilder(builder, type);
+                attribute.ConfigureApi(builder, type);
             }
         }
 
@@ -153,8 +152,7 @@ namespace Microsoft.Restier.Core
         /// <param name="type">
         /// The API type on which this attribute was placed.
         /// </param>
-        [CLSCompliant(false)]
-        public virtual void ConfigureBuilder(
+        public virtual void ConfigureApi(
             ApiBuilder builder,
             Type type)
         {

--- a/src/Microsoft.Restier.Core/ApiContext.cs
+++ b/src/Microsoft.Restier.Core/ApiContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Framework.DependencyInjection;
 using Microsoft.Restier.Core.Properties;
 
 namespace Microsoft.Restier.Core
@@ -16,6 +17,8 @@ namespace Microsoft.Restier.Core
     /// </remarks>
     public class ApiContext : PropertyBag
     {
+        private IServiceScope contextScope;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiContext" /> class.
         /// </summary>
@@ -31,11 +34,35 @@ namespace Microsoft.Restier.Core
             }
 
             this.Configuration = configuration;
+            this.contextScope = configuration.ServiceProvider.GetRequiredService<IApiScopeFactory>().CreateApiScope();
         }
 
         /// <summary>
         /// Gets the API configuration.
         /// </summary>
         public ApiConfiguration Configuration { get; private set; }
+
+        /// <summary>
+        /// Gets the <see cref="IServiceProvider"/> which contains all services of this <see cref="ApiContext"/>.
+        /// </summary>
+        public IServiceProvider ServiceProvider
+        {
+            get { return this.contextScope.ServiceProvider; }
+        }
+
+        /// <summary>
+        /// Gets a service instance.
+        /// </summary>
+        /// <typeparam name="T">The service type.</typeparam>
+        /// <returns>The service instance.</returns>
+        public T GetApiService<T>() where T : class
+        {
+            return this.ServiceProvider.GetService<T>();
+        }
+
+        internal void DisposeScope()
+        {
+            this.contextScope.Dispose();
+        }
     }
 }

--- a/src/Microsoft.Restier.Core/Conventions/ConventionBasedApiModelBuilder.cs
+++ b/src/Microsoft.Restier.Core/Conventions/ConventionBasedApiModelBuilder.cs
@@ -50,17 +50,17 @@ namespace Microsoft.Restier.Core.Conventions
 
         /// <inheritdoc/>
         public static void ApplyTo(
-            ApiConfiguration configuration,
+            ApiBuilder builder,
             Type targetType)
         {
-            Ensure.NotNull(configuration, "configuration");
+            Ensure.NotNull(builder, "builder");
             Ensure.NotNull(targetType, "targetType");
 
             var provider = new ConventionBasedApiModelBuilder(targetType);
-            configuration.AddHookHandler<IModelBuilder>(provider);
-            configuration.AddHookHandler<IModelMapper>(provider);
-            configuration.AddHookHandler<IQueryExpressionExpander>(provider);
-            configuration.AddHookHandler<IQueryExpressionSourcer>(provider);
+            builder.AddHookHandler<IModelBuilder>(provider);
+            builder.AddHookHandler<IModelMapper>(provider);
+            builder.AddHookHandler<IQueryExpressionExpander>(provider);
+            builder.AddHookHandler<IQueryExpressionSourcer>(provider);
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.Restier.Core/Conventions/ConventionBasedChangeSetAuthorizer.cs
+++ b/src/Microsoft.Restier.Core/Conventions/ConventionBasedChangeSetAuthorizer.cs
@@ -26,12 +26,12 @@ namespace Microsoft.Restier.Core.Conventions
 
         /// <inheritdoc/>
         public static void ApplyTo(
-            ApiConfiguration configuration,
+            ApiBuilder builder,
             Type targetType)
         {
-            Ensure.NotNull(configuration, "configuration");
+            Ensure.NotNull(builder, "builder");
             Ensure.NotNull(targetType, "targetType");
-            configuration.AddHookHandler<IChangeSetEntryAuthorizer>(new ConventionBasedChangeSetAuthorizer(targetType));
+            builder.AddHookHandler<IChangeSetEntryAuthorizer>(new ConventionBasedChangeSetAuthorizer(targetType));
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.Restier.Core/Conventions/ConventionBasedChangeSetEntryFilter.cs
+++ b/src/Microsoft.Restier.Core/Conventions/ConventionBasedChangeSetEntryFilter.cs
@@ -27,12 +27,12 @@ namespace Microsoft.Restier.Core.Conventions
 
         /// <inheritdoc/>
         public static void ApplyTo(
-            ApiConfiguration configuration,
+            ApiBuilder builder,
             Type targetType)
         {
-            Ensure.NotNull(configuration, "configuration");
+            Ensure.NotNull(builder, "builder");
             Ensure.NotNull(targetType, "targetType");
-            configuration.AddHookHandler<IChangeSetEntryFilter>(new ConventionBasedChangeSetEntryFilter(targetType));
+            builder.AddHookHandler<IChangeSetEntryFilter>(new ConventionBasedChangeSetEntryFilter(targetType));
         }
 
         /// <inheritdoc/>
@@ -59,32 +59,32 @@ namespace Microsoft.Restier.Core.Conventions
         {
             switch (entry.Type)
             {
-            case ChangeSetEntryType.DataModification:
-                DataModificationEntry dataModification = (DataModificationEntry)entry;
-                string operationName = null;
-                if (dataModification.IsNew)
-                {
-                    operationName = ConventionBasedChangeSetConstants.FilterMethodDataModificationInsert;
-                }
-                else if (dataModification.IsUpdate)
-                {
+                case ChangeSetEntryType.DataModification:
+                    DataModificationEntry dataModification = (DataModificationEntry)entry;
+                    string operationName = null;
+                    if (dataModification.IsNew)
+                    {
+                        operationName = ConventionBasedChangeSetConstants.FilterMethodDataModificationInsert;
+                    }
+                    else if (dataModification.IsUpdate)
+                    {
                         operationName = ConventionBasedChangeSetConstants.FilterMethodDataModificationUpdate;
-                }
-                else if (dataModification.IsDelete)
-                {
+                    }
+                    else if (dataModification.IsDelete)
+                    {
                         operationName = ConventionBasedChangeSetConstants.FilterMethodDataModificationDelete;
-                }
+                    }
 
-                return operationName + suffix + dataModification.EntitySetName;
+                    return operationName + suffix + dataModification.EntitySetName;
 
-            case ChangeSetEntryType.ActionInvocation:
-                ActionInvocationEntry actionEntry = (ActionInvocationEntry)entry;
-                return ConventionBasedChangeSetConstants.FilterMethodActionInvocationExecute +
-                       suffix + actionEntry.ActionName;
+                case ChangeSetEntryType.ActionInvocation:
+                    ActionInvocationEntry actionEntry = (ActionInvocationEntry)entry;
+                    return ConventionBasedChangeSetConstants.FilterMethodActionInvocationExecute +
+                           suffix + actionEntry.ActionName;
 
-            default:
-                throw new InvalidOperationException(string.Format(
-                    CultureInfo.InvariantCulture, Resources.InvalidChangeSetEntryType, entry.Type));
+                default:
+                    throw new InvalidOperationException(string.Format(
+                        CultureInfo.InvariantCulture, Resources.InvalidChangeSetEntryType, entry.Type));
             }
         }
 
@@ -92,17 +92,17 @@ namespace Microsoft.Restier.Core.Conventions
         {
             switch (entry.Type)
             {
-            case ChangeSetEntryType.DataModification:
-                DataModificationEntry dataModification = (DataModificationEntry)entry;
-                return new object[] { dataModification.Entity };
+                case ChangeSetEntryType.DataModification:
+                    DataModificationEntry dataModification = (DataModificationEntry)entry;
+                    return new object[] { dataModification.Entity };
 
-            case ChangeSetEntryType.ActionInvocation:
-                ActionInvocationEntry actionEntry = (ActionInvocationEntry)entry;
-                return actionEntry.GetArgumentArray();
+                case ChangeSetEntryType.ActionInvocation:
+                    ActionInvocationEntry actionEntry = (ActionInvocationEntry)entry;
+                    return actionEntry.GetArgumentArray();
 
-            default:
-                throw new InvalidOperationException(string.Format(
-                    CultureInfo.InvariantCulture, Resources.InvalidChangeSetEntryType, entry.Type));
+                default:
+                    throw new InvalidOperationException(string.Format(
+                        CultureInfo.InvariantCulture, Resources.InvalidChangeSetEntryType, entry.Type));
             }
         }
 

--- a/src/Microsoft.Restier.Core/Conventions/ConventionBasedEntitySetFilter.cs
+++ b/src/Microsoft.Restier.Core/Conventions/ConventionBasedEntitySetFilter.cs
@@ -23,12 +23,12 @@ namespace Microsoft.Restier.Core.Conventions
 
         /// <inheritdoc/>
         public static void ApplyTo(
-            ApiConfiguration configuration,
+            ApiBuilder builder,
             Type targetType)
         {
-            Ensure.NotNull(configuration, "configuration");
+            Ensure.NotNull(builder, "builder");
             Ensure.NotNull(targetType, "targetType");
-            configuration.AddHookHandler<IQueryExpressionFilter>(new ConventionBasedEntitySetFilter(targetType));
+            builder.AddHookHandler<IQueryExpressionFilter>(new ConventionBasedEntitySetFilter(targetType));
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.Restier.Core/Conventions/ConventionBasedOperationProvider.cs
+++ b/src/Microsoft.Restier.Core/Conventions/ConventionBasedOperationProvider.cs
@@ -27,10 +27,10 @@ namespace Microsoft.Restier.Core.Conventions
 
         public IModelBuilder InnerHandler { get; set; }
 
-        public static void ApplyTo(ApiConfiguration configuration, Type targetType)
+        public static void ApplyTo(ApiBuilder builder, Type targetType)
         {
             ConventionBasedOperationProvider provider = new ConventionBasedOperationProvider(targetType);
-            configuration.AddHookHandler<IModelBuilder>(provider);
+            builder.AddHookHandler<IModelBuilder>(provider);
         }
 
         public async Task<IEdmModel> GetModelAsync(InvocationContext context, CancellationToken cancellationToken)

--- a/src/Microsoft.Restier.Core/IApiScopeFactory.cs
+++ b/src/Microsoft.Restier.Core/IApiScopeFactory.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Framework.DependencyInjection;
+
+namespace Microsoft.Restier.Core
+{
+    /// <summary>
+    /// A factory to create <see cref="IServiceScope"/> for <see cref="ApiContext"/>.
+    /// </summary>
+    [CLSCompliant(false)]
+    public interface IApiScopeFactory
+    {
+        /// <summary>
+        /// Creates an <see cref="IServiceScope"/>.
+        /// </summary>
+        /// <returns>An <see cref="IServiceScope"/>.</returns>
+        IServiceScope CreateApiScope();
+    }
+}

--- a/src/Microsoft.Restier.Core/InvocationContext.cs
+++ b/src/Microsoft.Restier.Core/InvocationContext.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Restier.Core
         /// </remarks>
         public T GetHookHandler<T>() where T : class, IHookHandler
         {
-            return this.ApiContext.Configuration.GetHookHandler<T>();
+            return this.ApiContext.GetApiService<T>();
         }
     }
 }

--- a/src/Microsoft.Restier.Core/Microsoft.Restier.Core.csproj
+++ b/src/Microsoft.Restier.Core/Microsoft.Restier.Core.csproj
@@ -14,6 +14,14 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Framework.DependencyInjection, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Framework.DependencyInjection.1.0.0-beta8\lib\net45\Microsoft.Framework.DependencyInjection.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Framework.DependencyInjection.Abstractions, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Framework.DependencyInjection.Abstractions.1.0.0-beta8\lib\net45\Microsoft.Framework.DependencyInjection.Abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.OData.Edm, Version=6.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.OData.Edm.6.15.0-beta\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Edm.dll</HintPath>
       <Private>True</Private>
@@ -45,6 +53,9 @@
     <Compile Include="..\Shared\TypeExtensions.cs">
       <Link>Shared\TypeExtensions.cs</Link>
     </Compile>
+    <Compile Include="ApiBuilder.cs" />
+    <Compile Include="ApiBuilderExtensions.cs" />
+    <Compile Include="IApiScopeFactory.cs" />
     <Compile Include="Model\FunctionAttribute.cs" />
     <Compile Include="Model\ActionAttribute.cs" />
     <Compile Include="Conventions\ConventionBasedChangeSetAuthorizer.cs" />
@@ -104,7 +115,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Microsoft.Restier.Core.nuspec" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Properties\Resources.resx">

--- a/src/Microsoft.Restier.Core/packages.config
+++ b/src/Microsoft.Restier.Core/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Framework.DependencyInjection" version="1.0.0-beta8" targetFramework="net45" />
+  <package id="Microsoft.Framework.DependencyInjection.Abstractions" version="1.0.0-beta8" targetFramework="net45" />
   <package id="Microsoft.OData.Edm" version="6.15.0-beta" targetFramework="net45" />
 </packages>

--- a/src/Microsoft.Restier.EntityFramework/DbApi.cs
+++ b/src/Microsoft.Restier.EntityFramework/DbApi.cs
@@ -48,19 +48,23 @@ namespace Microsoft.Restier.EntityFramework
         /// <summary>
         /// Creates the API configuration for this API.
         /// </summary>
+        /// <param name="builder">
+        /// The <see cref="ApiBuilder"/> with which to create an <see cref="ApiConfiguration"/>.
+        /// </param>
         /// <returns>
         /// The API configuration for this API.
         /// </returns>
-        protected override ApiConfiguration CreateApiConfiguration()
+        [CLSCompliant(false)]
+        protected override ApiBuilder ConfigureApiBuilder(ApiBuilder builder)
         {
-            var configuration = base.CreateApiConfiguration();
-            configuration.AddHookHandler<IModelBuilder>(ModelProducer.Instance);
-            configuration.AddHookHandler<IModelMapper>(new ModelMapper(typeof(T)));
-            configuration.AddHookHandler<IQueryExpressionSourcer>(QueryExpressionSourcer.Instance);
-            configuration.AddHookHandler<IQueryExecutor>(QueryExecutor.Instance);
-            configuration.AddHookHandler<IChangeSetPreparer>(ChangeSetPreparer.Instance);
-            configuration.AddHookHandler<ISubmitExecutor>(SubmitExecutor.Instance);
-            return configuration;
+            builder = base.ConfigureApiBuilder(builder);
+            builder.AddHookHandler<IModelBuilder>(ModelProducer.Instance);
+            builder.AddHookHandler<IModelMapper>(new ModelMapper(typeof(T)));
+            builder.AddHookHandler<IQueryExpressionSourcer>(QueryExpressionSourcer.Instance);
+            builder.AddHookHandler<IQueryExecutor>(QueryExecutor.Instance);
+            builder.AddHookHandler<IChangeSetPreparer>(ChangeSetPreparer.Instance);
+            builder.AddHookHandler<ISubmitExecutor>(SubmitExecutor.Instance);
+            return builder;
         }
 
         /// <summary>

--- a/src/Microsoft.Restier.EntityFramework/DbApi.cs
+++ b/src/Microsoft.Restier.EntityFramework/DbApi.cs
@@ -54,10 +54,9 @@ namespace Microsoft.Restier.EntityFramework
         /// <returns>
         /// The API configuration for this API.
         /// </returns>
-        [CLSCompliant(false)]
-        protected override ApiBuilder ConfigureApiBuilder(ApiBuilder builder)
+        protected override ApiBuilder ConfigureApi(ApiBuilder builder)
         {
-            builder = base.ConfigureApiBuilder(builder);
+            builder = base.ConfigureApi(builder);
             builder.AddHookHandler<IModelBuilder>(ModelProducer.Instance);
             builder.AddHookHandler<IModelMapper>(new ModelMapper(typeof(T)));
             builder.AddHookHandler<IQueryExpressionSourcer>(QueryExpressionSourcer.Instance);

--- a/src/Microsoft.Restier.EntityFramework7/Microsoft.Restier.EntityFramework7.csproj
+++ b/src/Microsoft.Restier.EntityFramework7/Microsoft.Restier.EntityFramework7.csproj
@@ -73,8 +73,8 @@
       <HintPath>..\..\packages\Microsoft.Framework.OptionsModel.1.0.0-beta8\lib\net45\Microsoft.Framework.OptionsModel.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=6.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\Packages\Microsoft.OData.Edm.6.13.0\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Edm.dll</HintPath>
+    <Reference Include="Microsoft.OData.Edm, Version=6.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.OData.Edm.6.15.0-beta\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Edm.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Remotion.Linq, Version=2.0.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">

--- a/src/Microsoft.Restier.EntityFramework7/packages.config
+++ b/src/Microsoft.Restier.EntityFramework7/packages.config
@@ -13,7 +13,7 @@
   <package id="Microsoft.Framework.Logging" version="1.0.0-beta8" targetFramework="net451" />
   <package id="Microsoft.Framework.Logging.Abstractions" version="1.0.0-beta8" targetFramework="net451" />
   <package id="Microsoft.Framework.OptionsModel" version="1.0.0-beta8" targetFramework="net451" />
-  <package id="Microsoft.OData.Edm" version="6.13.0" targetFramework="net451" />
+  <package id="Microsoft.OData.Edm" version="6.15.0-beta" targetFramework="net451" />
   <package id="Remotion.Linq" version="2.0.0" targetFramework="net451" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net451" />
 </packages>

--- a/src/Microsoft.Restier.Samples.Northwind.EF7/Microsoft.Restier.Samples.Northwind.EF7.csproj
+++ b/src/Microsoft.Restier.Samples.Northwind.EF7/Microsoft.Restier.Samples.Northwind.EF7.csproj
@@ -98,16 +98,16 @@
       <HintPath>..\..\packages\Microsoft.Framework.Primitives.1.0.0-beta8\lib\net45\Microsoft.Framework.Primitives.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Core, Version=6.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\Packages\Microsoft.OData.Core.6.13.0\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Core.dll</HintPath>
+    <Reference Include="Microsoft.OData.Core, Version=6.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.OData.Core.6.15.0-beta\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=6.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\Packages\Microsoft.OData.Edm.6.13.0\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Edm.dll</HintPath>
+    <Reference Include="Microsoft.OData.Edm, Version=6.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.OData.Edm.6.15.0-beta\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Edm.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Spatial, Version=6.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\Packages\Microsoft.Spatial.6.13.0\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.Spatial.dll</HintPath>
+    <Reference Include="Microsoft.Spatial, Version=6.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Spatial.6.15.0-beta\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -139,8 +139,8 @@
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web" />
-    <Reference Include="System.Web.OData, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\Packages\Microsoft.AspNet.OData.5.7.0\lib\net45\System.Web.OData.dll</HintPath>
+    <Reference Include="System.Web.OData, Version=5.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.OData.5.9.0-Nightly160127\lib\net45\System.Web.OData.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />

--- a/src/Microsoft.Restier.Samples.Northwind.EF7/Microsoft.Restier.Samples.Northwind.EF7.csproj
+++ b/src/Microsoft.Restier.Samples.Northwind.EF7/Microsoft.Restier.Samples.Northwind.EF7.csproj
@@ -140,7 +140,7 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.OData, Version=5.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.OData.5.9.0-Nightly160127\lib\net45\System.Web.OData.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.OData.5.9.0-Nightly160216\lib\net45\System.Web.OData.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />

--- a/src/Microsoft.Restier.Samples.Northwind.EF7/Web.config
+++ b/src/Microsoft.Restier.Samples.Northwind.EF7/Web.config
@@ -57,15 +57,15 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.OData.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.12.0.0" newVersion="6.12.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.13.0.0" newVersion="6.13.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.OData.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.12.0.0" newVersion="6.12.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.15.0.0" newVersion="6.15.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Spatial" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.12.0.0" newVersion="6.12.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.15.0.0" newVersion="6.15.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Remotion.Linq" publicKeyToken="fee00910d6e5f53b" culture="neutral" />

--- a/src/Microsoft.Restier.Samples.Northwind.EF7/packages.config
+++ b/src/Microsoft.Restier.Samples.Northwind.EF7/packages.config
@@ -4,7 +4,7 @@
   <package id="EntityFramework.Relational" version="7.0.0-beta8" targetFramework="net451" />
   <package id="EntityFramework.SqlServer" version="7.0.0-beta8" targetFramework="net451" />
   <package id="Ix-Async" version="1.2.5" targetFramework="net451" />
-  <package id="Microsoft.AspNet.OData" version="5.7.0" targetFramework="net45" />
+  <package id="Microsoft.AspNet.OData" version="5.9.0-Nightly160127" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.2" targetFramework="net45" />
@@ -20,9 +20,9 @@
   <package id="Microsoft.Framework.Logging.Abstractions" version="1.0.0-beta8" targetFramework="net451" />
   <package id="Microsoft.Framework.OptionsModel" version="1.0.0-beta8" targetFramework="net451" />
   <package id="Microsoft.Framework.Primitives" version="1.0.0-beta8" targetFramework="net451" />
-  <package id="Microsoft.OData.Core" version="6.13.0" targetFramework="net45" />
-  <package id="Microsoft.OData.Edm" version="6.13.0" targetFramework="net45" />
-  <package id="Microsoft.Spatial" version="6.13.0" targetFramework="net45" />
+  <package id="Microsoft.OData.Core" version="6.15.0-beta" targetFramework="net451" />
+  <package id="Microsoft.OData.Edm" version="6.15.0-beta" targetFramework="net451" />
+  <package id="Microsoft.Spatial" version="6.15.0-beta" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
   <package id="Remotion.Linq" version="2.0.0" targetFramework="net451" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net451" />

--- a/src/Microsoft.Restier.Samples.Northwind.EF7/packages.config
+++ b/src/Microsoft.Restier.Samples.Northwind.EF7/packages.config
@@ -4,7 +4,7 @@
   <package id="EntityFramework.Relational" version="7.0.0-beta8" targetFramework="net451" />
   <package id="EntityFramework.SqlServer" version="7.0.0-beta8" targetFramework="net451" />
   <package id="Ix-Async" version="1.2.5" targetFramework="net451" />
-  <package id="Microsoft.AspNet.OData" version="5.9.0-Nightly160127" targetFramework="net451" />
+  <package id="Microsoft.AspNet.OData" version="5.9.0-Nightly160216" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.2" targetFramework="net45" />

--- a/src/Microsoft.Restier.Samples.Northwind/Microsoft.Restier.Samples.Northwind.csproj
+++ b/src/Microsoft.Restier.Samples.Northwind/Microsoft.Restier.Samples.Northwind.csproj
@@ -76,7 +76,7 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.OData, Version=5.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.OData.5.9.0-Nightly160127\lib\net45\System.Web.OData.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.OData.5.9.0-Nightly160216\lib\net45\System.Web.OData.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/src/Microsoft.Restier.Samples.Northwind/Models/NorthwindApi.cs
+++ b/src/Microsoft.Restier.Samples.Northwind/Models/NorthwindApi.cs
@@ -66,9 +66,9 @@ namespace Microsoft.Restier.Samples.Northwind.Models
             return 0.0;
         }
 
-        protected override ApiBuilder ConfigureApiBuilder(ApiBuilder builder)
+        protected override ApiBuilder ConfigureApi(ApiBuilder builder)
         {
-            return base.ConfigureApiBuilder(builder)
+            return base.ConfigureApi(builder)
                 .AddHookHandler<IModelBuilder>(new NorthwindModelExtender());
         }
 

--- a/src/Microsoft.Restier.Samples.Northwind/Models/NorthwindApi.cs
+++ b/src/Microsoft.Restier.Samples.Northwind/Models/NorthwindApi.cs
@@ -66,9 +66,10 @@ namespace Microsoft.Restier.Samples.Northwind.Models
             return 0.0;
         }
 
-        protected override ApiConfiguration CreateApiConfiguration()
+        protected override ApiBuilder ConfigureApiBuilder(ApiBuilder builder)
         {
-            return base.CreateApiConfiguration().AddHookHandler<IModelBuilder>(new NorthwindModelExtender());
+            return base.ConfigureApiBuilder(builder)
+                .AddHookHandler<IModelBuilder>(new NorthwindModelExtender());
         }
 
         // Entity set filter

--- a/src/Microsoft.Restier.Samples.Northwind/packages.config
+++ b/src/Microsoft.Restier.Samples.Northwind/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EntityFramework" version="6.1.1" targetFramework="net45" />
-  <package id="Microsoft.AspNet.OData" version="5.9.0-Nightly160127" targetFramework="net45" />
+  <package id="Microsoft.AspNet.OData" version="5.9.0-Nightly160216" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.2" targetFramework="net45" />

--- a/src/Microsoft.Restier.Security/ApiConfigurationExtensions.cs
+++ b/src/Microsoft.Restier.Security/ApiConfigurationExtensions.cs
@@ -31,7 +31,6 @@ namespace Microsoft.Restier.Security
         /// authorize according to roles assigned to the current principal
         /// along with any that have been asserted during an API flow.
         /// </remarks>
-        [CLSCompliant(false)]
         public static void EnableRoleBasedSecurity(
             this ApiBuilder builder)
         {

--- a/src/Microsoft.Restier.Security/ApiConfigurationExtensions.cs
+++ b/src/Microsoft.Restier.Security/ApiConfigurationExtensions.cs
@@ -23,20 +23,21 @@ namespace Microsoft.Restier.Security
         /// <summary>
         /// Enables principal-supplied role-based security for an API.
         /// </summary>
-        /// <param name="configuration">
-        /// An API configuration.
+        /// <param name="builder">
+        /// An API configuration builder.
         /// </param>
         /// <remarks>
         /// This method adds hook points to the API configuration that
         /// authorize according to roles assigned to the current principal
         /// along with any that have been asserted during an API flow.
         /// </remarks>
+        [CLSCompliant(false)]
         public static void EnableRoleBasedSecurity(
-            this ApiConfiguration configuration)
+            this ApiBuilder builder)
         {
-            Ensure.NotNull(configuration, "configuration");
-            configuration.AddHookHandler<IQueryExpressionInspector>(RoleBasedAuthorization.Default);
-            configuration.AddHookHandler<IQueryExpressionExpander>(RoleBasedAuthorization.Default);
+            Ensure.NotNull(builder, "configuration");
+            builder.AddHookHandler<IQueryExpressionInspector>(RoleBasedAuthorization.Default);
+            builder.AddHookHandler<IQueryExpressionExpander>(RoleBasedAuthorization.Default);
         }
 
         /// <summary>

--- a/src/Microsoft.Restier.Security/EnableRoleBasedSecurityAttribute.cs
+++ b/src/Microsoft.Restier.Security/EnableRoleBasedSecurityAttribute.cs
@@ -23,8 +23,7 @@ namespace Microsoft.Restier.Security
         /// <param name="type">
         /// The API type on which this attribute was placed.
         /// </param>
-        [CLSCompliant(false)]
-        public override void ConfigureBuilder(
+        public override void ConfigureApi(
             ApiBuilder builder,
             Type type)
         {

--- a/src/Microsoft.Restier.Security/EnableRoleBasedSecurityAttribute.cs
+++ b/src/Microsoft.Restier.Security/EnableRoleBasedSecurityAttribute.cs
@@ -17,17 +17,18 @@ namespace Microsoft.Restier.Security
         /// <summary>
         /// Configures an API configuration.
         /// </summary>
-        /// <param name="configuration">
-        /// An API configuration.
+        /// <param name="builder">
+        /// An API configuration builder.
         /// </param>
         /// <param name="type">
         /// The API type on which this attribute was placed.
         /// </param>
-        public override void Configure(
-            ApiConfiguration configuration,
+        [CLSCompliant(false)]
+        public override void ConfigureBuilder(
+            ApiBuilder builder,
             Type type)
         {
-            configuration.EnableRoleBasedSecurity();
+            builder.EnableRoleBasedSecurity();
         }
     }
 }

--- a/src/Microsoft.Restier.WebApi/Microsoft.Restier.WebApi.csproj
+++ b/src/Microsoft.Restier.WebApi/Microsoft.Restier.WebApi.csproj
@@ -41,7 +41,7 @@
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.2.2\lib\net45\System.Web.Http.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.OData, Version=5.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.OData.5.9.0-Nightly160127\lib\net45\System.Web.OData.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.OData.5.9.0-Nightly160216\lib\net45\System.Web.OData.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />
@@ -124,7 +124,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="Microsoft.Restier.WebApi.nuspec">
       <SubType>Designer</SubType>
     </None>

--- a/src/Microsoft.Restier.WebApi/packages.config
+++ b/src/Microsoft.Restier.WebApi/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.OData" version="5.9.0-Nightly160127" targetFramework="net45" />
+  <package id="Microsoft.AspNet.OData" version="5.9.0-Nightly160216" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.OData.Core" version="6.15.0-beta" targetFramework="net45" />

--- a/test/Microsoft.Restier.Core.Tests/Api.Tests.cs
+++ b/test/Microsoft.Restier.Core.Tests/Api.Tests.cs
@@ -89,19 +89,18 @@ namespace Microsoft.Restier.Core.Tests
                 {
                     if (_context == null)
                     {
-                        var configuration = new ApiConfiguration();
+                        var builder = new ApiBuilder();
                         var modelBuilder = new TestModelBuilder();
                         var modelMapper = new TestModelMapper();
                         var querySourcer = new TestQuerySourcer();
                         var changeSetPreparer = new TestChangeSetPreparer();
                         var submitExecutor = new TestSubmitExecutor();
-                        configuration.AddHookHandler<IModelBuilder>(modelBuilder);
-                        configuration.AddHookHandler<IModelMapper>(modelMapper);
-                        configuration.AddHookHandler<IQueryExpressionSourcer>(querySourcer);
-                        configuration.AddHookHandler<IChangeSetPreparer>(changeSetPreparer);
-                        configuration.AddHookHandler<ISubmitExecutor>(submitExecutor);
-                        configuration.EnsureCommitted();
-                        _context = new ApiContext(configuration);
+                        builder.AddHookHandler<IModelBuilder>(modelBuilder);
+                        builder.AddHookHandler<IModelMapper>(modelMapper);
+                        builder.AddHookHandler<IQueryExpressionSourcer>(querySourcer);
+                        builder.AddHookHandler<IChangeSetPreparer>(changeSetPreparer);
+                        builder.AddHookHandler<ISubmitExecutor>(submitExecutor);
+                        _context = new ApiContext(builder.Build());
                     }
 
                     return _context;
@@ -138,7 +137,7 @@ namespace Microsoft.Restier.Core.Tests
         [Fact]
         public void SourceOfEntityContainerElementThrowsIfNotMapped()
         {
-            var configuration = new ApiConfiguration();
+            var configuration = new ApiBuilder().Build();
             configuration.EnsureCommitted();
             var context = new ApiContext(configuration);
             var arguments = new object[0];
@@ -149,9 +148,10 @@ namespace Microsoft.Restier.Core.Tests
         [Fact]
         public void SourceOfEntityContainerElementIsCorrect()
         {
-            var configuration = new ApiConfiguration();
             var modelMapper = new TestModelMapper();
-            configuration.AddHookHandler<IModelMapper>(modelMapper);
+            var configuration = new ApiBuilder()
+                .AddHookHandler<IModelMapper>(modelMapper)
+                .Build();
             configuration.EnsureCommitted();
             var context = new ApiContext(configuration);
             var arguments = new object[0];
@@ -199,7 +199,7 @@ namespace Microsoft.Restier.Core.Tests
         [Fact]
         public void SourceOfComposableFunctionThrowsIfNotMapped()
         {
-            var configuration = new ApiConfiguration();
+            var configuration = new ApiBuilder().Build();
             configuration.EnsureCommitted();
             var context = new ApiContext(configuration);
             var arguments = new object[0];
@@ -210,9 +210,10 @@ namespace Microsoft.Restier.Core.Tests
         [Fact]
         public void SourceOfComposableFunctionIsCorrect()
         {
-            var configuration = new ApiConfiguration();
             var modelMapper = new TestModelMapper();
-            configuration.AddHookHandler<IModelMapper>(modelMapper);
+            var configuration = new ApiBuilder()
+                .AddHookHandler<IModelMapper>(modelMapper)
+                .Build();
             configuration.EnsureCommitted();
             var context = new ApiContext(configuration);
             var arguments = new object[0];
@@ -261,9 +262,10 @@ namespace Microsoft.Restier.Core.Tests
         [Fact]
         public void GenericSourceOfEntityContainerElementThrowsIfWrongType()
         {
-            var configuration = new ApiConfiguration();
             var modelMapper = new TestModelMapper();
-            configuration.AddHookHandler<IModelMapper>(modelMapper);
+            var configuration = new ApiBuilder()
+                .AddHookHandler<IModelMapper>(modelMapper)
+                .Build();
             configuration.EnsureCommitted();
             var context = new ApiContext(configuration);
             var arguments = new object[0];
@@ -274,9 +276,10 @@ namespace Microsoft.Restier.Core.Tests
         [Fact]
         public void GenericSourceOfEntityContainerElementIsCorrect()
         {
-            var configuration = new ApiConfiguration();
             var modelMapper = new TestModelMapper();
-            configuration.AddHookHandler<IModelMapper>(modelMapper);
+            var configuration = new ApiBuilder()
+                .AddHookHandler<IModelMapper>(modelMapper)
+                .Build();
             configuration.EnsureCommitted();
             var context = new ApiContext(configuration);
             var arguments = new object[0];
@@ -325,9 +328,10 @@ namespace Microsoft.Restier.Core.Tests
         [Fact]
         public void GenericSourceOfComposableFunctionThrowsIfWrongType()
         {
-            var configuration = new ApiConfiguration();
             var modelMapper = new TestModelMapper();
-            configuration.AddHookHandler<IModelMapper>(modelMapper);
+            var configuration = new ApiBuilder()
+                .AddHookHandler<IModelMapper>(modelMapper)
+                .Build();
             configuration.EnsureCommitted();
             var context = new ApiContext(configuration);
             var arguments = new object[0];
@@ -338,9 +342,10 @@ namespace Microsoft.Restier.Core.Tests
         [Fact]
         public void GenericSourceOfComposableFunctionIsCorrect()
         {
-            var configuration = new ApiConfiguration();
             var modelMapper = new TestModelMapper();
-            configuration.AddHookHandler<IModelMapper>(modelMapper);
+            var configuration = new ApiBuilder()
+                .AddHookHandler<IModelMapper>(modelMapper)
+                .Build();
             configuration.EnsureCommitted();
             var context = new ApiContext(configuration);
             var arguments = new object[0];
@@ -367,9 +372,10 @@ namespace Microsoft.Restier.Core.Tests
         [Fact]
         public void SourceQueryableCannotGenericEnumerate()
         {
-            var configuration = new ApiConfiguration();
             var modelMapper = new TestModelMapper();
-            configuration.AddHookHandler<IModelMapper>(modelMapper);
+            var configuration = new ApiBuilder()
+                .AddHookHandler<IModelMapper>(modelMapper)
+                .Build();
             configuration.EnsureCommitted();
             var context = new ApiContext(configuration);
 
@@ -380,9 +386,10 @@ namespace Microsoft.Restier.Core.Tests
         [Fact]
         public void SourceQueryableCannotEnumerate()
         {
-            var configuration = new ApiConfiguration();
             var modelMapper = new TestModelMapper();
-            configuration.AddHookHandler<IModelMapper>(modelMapper);
+            var configuration = new ApiBuilder()
+                .AddHookHandler<IModelMapper>(modelMapper)
+                .Build();
             configuration.EnsureCommitted();
             var context = new ApiContext(configuration);
 
@@ -393,9 +400,10 @@ namespace Microsoft.Restier.Core.Tests
         [Fact]
         public void SourceQueryProviderCannotGenericExecute()
         {
-            var configuration = new ApiConfiguration();
             var modelMapper = new TestModelMapper();
-            configuration.AddHookHandler<IModelMapper>(modelMapper);
+            var configuration = new ApiBuilder()
+                .AddHookHandler<IModelMapper>(modelMapper)
+                .Build();
             configuration.EnsureCommitted();
             var context = new ApiContext(configuration);
 
@@ -406,9 +414,10 @@ namespace Microsoft.Restier.Core.Tests
         [Fact]
         public void SourceQueryProviderCannotExecute()
         {
-            var configuration = new ApiConfiguration();
             var modelMapper = new TestModelMapper();
-            configuration.AddHookHandler<IModelMapper>(modelMapper);
+            var configuration = new ApiBuilder()
+                .AddHookHandler<IModelMapper>(modelMapper)
+                .Build();
             configuration.EnsureCommitted();
             var context = new ApiContext(configuration);
 

--- a/test/Microsoft.Restier.Core.Tests/ApiBuilder.Tests.cs
+++ b/test/Microsoft.Restier.Core.Tests/ApiBuilder.Tests.cs
@@ -1,0 +1,168 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.OData.Edm;
+using Microsoft.Restier.Core.Model;
+using Xunit;
+
+namespace Microsoft.Restier.Core.Tests
+{
+    public class ApiBuilderTests
+    {
+        interface ISomeService
+        {
+            string Call();
+        }
+
+        class SomeService : ISomeService
+        {
+            public int Value
+            {
+                get; set;
+            }
+
+            public ISomeService Next
+            {
+                get; set;
+            }
+
+            public string Call()
+            {
+                if (Next == null)
+                {
+                    return Value.ToString();
+                }
+
+                return Value + Next.Call();
+            }
+        }
+
+        [Fact]
+        public void ContributorsAreCalledCorrectly()
+        {
+            int i = 0;
+            var builder = new ApiBuilder()
+                .AddContributor<ISomeService>((sp, next) => new SomeService()
+                {
+                    Next = next(),
+                    Value = i++,
+                })
+                .AddContributor<ISomeService>((sp, next) => new SomeService()
+                {
+                    Next = next(),
+                    Value = i++,
+                })
+                .ChainPrevious<ISomeService>(next => new SomeService()
+                {
+                    Next = next,
+                    Value = i++,
+                })
+                .ChainPrevious<ISomeService>((sp, next) => new SomeService()
+                {
+                    Next = next,
+                    Value = i++,
+                });
+
+            var configuration = builder.Build();
+            var value = configuration.GetHookHandler<ISomeService>().Call();
+            Assert.Equal("3210", value);
+        }
+
+        interface ISomeHook : ISomeService, IHookHandler
+        {
+        }
+
+        class SomeHook : SomeService, ISomeHook
+        {
+        }
+
+        class SomeDelegateHook : SomeHook, IDelegateHookHandler<ISomeHook>
+        {
+            public ISomeHook InnerHandler
+            {
+                get { return (ISomeHook)Next; }
+                set { Next = value; }
+            }
+        }
+
+        [Fact]
+        public void LegacyHookHandlerChainContributor()
+        {
+            var builder = new ApiBuilder()
+                .AddContributor<ISomeHook>((sp, next) => new SomeHook()
+                {
+                    Next = next(),
+                    Value = 0,
+                })
+                .AddHookHandler<ISomeHook>(new SomeDelegateHook()
+                {
+                    Value = 1,
+                });
+
+            var configuration = builder.Build();
+            var value = configuration.GetHookHandler<ISomeHook>().Call();
+            Assert.Equal("10", value);
+        }
+
+        [Fact]
+        public void ContributorChainLegacyHookHandler()
+        {
+            var builder = new ApiBuilder()
+                .AddHookHandler<ISomeHook>(new SomeDelegateHook()
+                {
+                    Value = 1,
+                })
+                .AddContributor<ISomeHook>((sp, next) => new SomeHook()
+                {
+                    Next = next(),
+                    Value = 0,
+                });
+
+            var configuration = builder.Build();
+            var value = configuration.GetHookHandler<ISomeHook>().Call();
+            Assert.Equal("01", value);
+        }
+
+        [Fact]
+        public void SharedApiScopeWorksCorrectly()
+        {
+            var builder = new ApiBuilder()
+                .TryUseSharedApiScope()
+                .MakeScoped<ISomeService>()
+                .ChainPrevious<ISomeService>(next => new SomeService());
+
+            var configuration = builder.Build();
+            var service1 = configuration.GetHookHandler<ISomeService>();
+
+            var context = new ApiContext(configuration);
+            var service2 = context.GetApiService<ISomeService>();
+
+            Assert.Equal(service1, service2);
+        }
+
+        [Fact]
+        public void ContextApiScopeWorksCorrectly()
+        {
+            var builder = new ApiBuilder()
+                .MakeScoped<ISomeService>()
+                .ChainPrevious<ISomeService>(next => new SomeService());
+
+            var configuration = builder.Build();
+            var service1 = configuration.GetHookHandler<ISomeService>();
+
+            var context = new ApiContext(configuration);
+            var service2 = context.GetApiService<ISomeService>();
+
+            Assert.NotEqual(service1, service2);
+
+            var context3 = new ApiContext(configuration);
+            var service3 = context3.GetApiService<ISomeService>();
+
+            Assert.NotEqual(service3, service2);
+        }
+    }
+}

--- a/test/Microsoft.Restier.Core.Tests/ApiBuilder.Tests.cs
+++ b/test/Microsoft.Restier.Core.Tests/ApiBuilder.Tests.cs
@@ -20,6 +20,15 @@ namespace Microsoft.Restier.Core.Tests
 
         class SomeService : ISomeService
         {
+            public SomeService(ISomeService next)
+            {
+                Next = next;
+            }
+
+            public SomeService()
+            {
+            }
+
             public int Value
             {
                 get; set;
@@ -65,11 +74,33 @@ namespace Microsoft.Restier.Core.Tests
                 {
                     Next = next,
                     Value = i++,
-                });
+                })
+                .ChainPrevious<ISomeService, SomeService>();
 
             var configuration = builder.Build();
             var value = configuration.GetHookHandler<ISomeService>().Call();
-            Assert.Equal("3210", value);
+            Assert.Equal("03210", value);
+        }
+
+        [Fact]
+        public void NextInjectedViaConstructor()
+        {
+            var builder = new ApiBuilder()
+                .AddContributor<ISomeService>((sp, next) => new SomeService()
+                {
+                    Next = next(),
+                    Value = 1,
+                })
+                .ChainPrevious<ISomeService, SomeService>()
+                .MakeTransient<ISomeService>();
+
+            var configuration = builder.Build();
+            var value = configuration.GetHookHandler<ISomeService>().Call();
+            Assert.Equal("01", value);
+
+            // Test expression compilation.
+            value = configuration.GetHookHandler<ISomeService>().Call();
+            Assert.Equal("01", value);
         }
 
         interface ISomeHook : ISomeService, IHookHandler
@@ -163,6 +194,230 @@ namespace Microsoft.Restier.Core.Tests
             var service3 = context3.GetApiService<ISomeService>();
 
             Assert.NotEqual(service3, service2);
+        }
+
+        class SomeServiceNoChain : ISomeService
+        {
+            public string Call()
+            {
+                return "42";
+            }
+        }
+
+        [Fact]
+        public void NothingInjectedStillWorks()
+        {
+            var builder = new ApiBuilder()
+                .AddContributor<ISomeService>((sp, next) => new SomeService()
+                {
+                    Next = next(),
+                    Value = 1,
+                })
+                .ChainPrevious<ISomeService, SomeServiceNoChain>()
+                .MakeTransient<ISomeService>();
+
+            var configuration = builder.Build();
+            var value = configuration.GetHookHandler<ISomeService>().Call();
+            Assert.Equal("42", value);
+
+            // Test expression compilation.
+            value = configuration.GetHookHandler<ISomeService>().Call();
+            Assert.Equal("42", value);
+            value = configuration.GetHookHandler<ISomeService>().Call();
+            Assert.Equal("42", value);
+        }
+
+        class SomeService2 : ISomeService
+        {
+            public SomeService2(ISomeService next, string value = "4")
+            {
+                Next = next;
+                Value = value;
+            }
+
+            public string Value
+            {
+                get; set;
+            }
+
+            public ISomeService Next
+            {
+                get; set;
+            }
+
+            public string Call()
+            {
+                if (Next == null)
+                {
+                    return Value.ToString();
+                }
+
+                return Value + Next.Call();
+            }
+        }
+
+        [Fact]
+        public void ServiceInjectedViaConstructor()
+        {
+            var first = new SomeService()
+            {
+                Value = 42,
+            };
+            var builder = new ApiBuilder()
+                .MakeTransient<ISomeService>()
+                .AddContributor<ISomeService>((sp, next) => first)
+                .ChainPrevious<ISomeService, SomeService2>()
+                .AddInstance<string>("Text");
+
+            var configuration = builder.Build();
+            var expected = "Text42";
+            var value = configuration.GetHookHandler<ISomeService>().Call();
+            Assert.Equal(expected, value);
+
+            value = configuration.GetHookHandler<ISomeService>().Call();
+            Assert.Equal(expected, value);
+
+            value = configuration.GetHookHandler<ISomeService>().Call();
+            Assert.Equal(expected, value);
+
+            Assert.NotEqual(
+                configuration.GetHookHandler<ISomeService>(),
+                configuration.GetHookHandler<ISomeService>());
+        }
+
+        [Fact]
+        public void DefaultValueInConstructorUsedIfNoService()
+        {
+            var builder = new ApiBuilder()
+                .AddContributor<ISomeService>((sp, next) => new SomeService()
+                {
+                    Value = 2,
+                })
+                .MakeTransient<ISomeService>()
+                .ChainPrevious<ISomeService, SomeService2>();
+
+            var configuration = builder.Build();
+            var value = configuration.GetHookHandler<ISomeService>().Call();
+            Assert.Equal("42", value);
+
+            value = configuration.GetHookHandler<ISomeService>().Call();
+            Assert.Equal("42", value);
+            value = configuration.GetHookHandler<ISomeService>().Call();
+            Assert.Equal("42", value);
+        }
+
+        class SomeService3 : ISomeService
+        {
+            public SomeService3(string value, ISomeService next, SomeService dep1, SomeService dep2)
+            {
+                Value = value;
+                Next = next;
+                Param2 = dep1;
+                Param3 = dep2;
+            }
+
+            public SomeService3(ISomeService next, SomeService dep1)
+            {
+                Value = "4";
+                Next = next;
+                Param2 = Param3 = dep1;
+            }
+
+            public string Value { get; set; }
+
+            public ISomeService Next { get; set; }
+
+            public SomeService Param2 { get; set; }
+
+            public SomeService Param3 { get; set; }
+
+            public string Call()
+            {
+                return Value +
+                    (Next == null ? string.Empty : Next.Call()) +
+                    Param2.Call() +
+                    Param3.Call();
+            }
+        }
+
+        [Fact]
+        public void MultiInjectionViaConstructor()
+        {
+            var builder = new ApiBuilder()
+                .AddContributor<ISomeService>((sp, next) => new SomeService()
+                {
+                    Value = 1,
+                })
+                .MakeTransient<ISomeService>()
+                .AddContributor<string>((sp, next) =>
+                {
+                    return "0";
+                })
+                .MakeTransient<string>()
+                .ChainPrevious<ISomeService, SomeService3>()
+                .AddInstance<SomeService>(new SomeService()
+                {
+                    Value = 2,
+                });
+
+            var configuration = builder.Build();
+            var value = configuration.GetHookHandler<ISomeService>().Call();
+            Assert.Equal("0122", value);
+
+            // Test expression compilation
+            value = configuration.GetHookHandler<ISomeService>().Call();
+            Assert.Equal("0122", value);
+            value = configuration.GetHookHandler<ISomeService>().Call();
+            Assert.Equal("0122", value);
+        }
+
+        [Fact]
+        public void ThrowOnNoServiceFound()
+        {
+            var builder = new ApiBuilder()
+                .AddContributor<ISomeService>((sp, next) => new SomeService()
+                {
+                    Value = 1,
+                })
+                .MakeTransient<ISomeService>()
+                .AddContributor<string>((sp, next) =>
+                {
+                    return "0";
+                })
+                .MakeTransient<string>()
+                .ChainPrevious<ISomeService, SomeService3>();
+
+            var configuration = builder.Build();
+            Assert.Throws<NotSupportedException>(() =>
+            {
+                configuration.GetHookHandler<ISomeService>();
+            });
+        }
+
+        [Fact]
+        public void AvailableServicesSelectConstructor()
+        {
+            var builder = new ApiBuilder()
+                .MakeTransient<ISomeService>()
+                .AddContributor<ISomeService>((sp, next) => new SomeService()
+                {
+                    Value = 2,
+                })
+                .AddInstance(new SomeService()
+                {
+                    Value = 0,
+                })
+                .ChainPrevious<ISomeService, SomeService3>();
+
+            var configuration = builder.Build();
+            var value = configuration.GetHookHandler<ISomeService>().Call();
+            Assert.Equal("4200", value);
+
+            // Test expression compilation
+            value = configuration.GetHookHandler<ISomeService>().Call();
+            Assert.Equal("4200", value);
+            value = configuration.GetHookHandler<ISomeService>().Call();
+            Assert.Equal("4200", value);
         }
     }
 }

--- a/test/Microsoft.Restier.Core.Tests/ApiContext.Tests.cs
+++ b/test/Microsoft.Restier.Core.Tests/ApiContext.Tests.cs
@@ -9,16 +9,9 @@ namespace Microsoft.Restier.Core.Tests
     public class ApiContextTests
     {
         [Fact]
-        public void ApiContextOnlyAcceptsCommittedConfiguration()
-        {
-            var configuration = new ApiConfiguration();
-            Assert.Throws<ArgumentException>(() => new ApiContext(configuration));
-        }
-
-        [Fact]
         public void NewApiContextIsConfiguredCorrectly()
         {
-            var configuration = new ApiConfiguration();
+            var configuration = new ApiBuilder().Build();
             configuration.EnsureCommitted();
             var context = new ApiContext(configuration);
             Assert.Same(configuration, context.Configuration);

--- a/test/Microsoft.Restier.Core.Tests/InvocationContext.Tests.cs
+++ b/test/Microsoft.Restier.Core.Tests/InvocationContext.Tests.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Restier.Core.Tests
         [Fact]
         public void NewInvocationContextIsConfiguredCorrectly()
         {
-            var configuration = new ApiConfiguration();
+            var configuration = new ApiBuilder().Build();
             configuration.EnsureCommitted();
             var apiContext = new ApiContext(configuration);
             var context = new InvocationContext(apiContext);
@@ -21,7 +21,7 @@ namespace Microsoft.Restier.Core.Tests
         public void InvocationContextGetsHookPointsCorrectly()
         {
             var hook = new HookA();
-            var configuration = new ApiConfiguration().AddHookHandler<IHookA>(hook);
+            var configuration = new ApiBuilder().AddHookHandler<IHookA>(hook).Build();
             configuration.EnsureCommitted();
             var apiContext = new ApiContext(configuration);
             var context = new InvocationContext(apiContext);

--- a/test/Microsoft.Restier.Core.Tests/Microsoft.Restier.Core.Tests.csproj
+++ b/test/Microsoft.Restier.Core.Tests/Microsoft.Restier.Core.Tests.csproj
@@ -58,6 +58,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ApiBuilder.Tests.cs" />
     <Compile Include="Model\ConventionBasedApiModelBuilder.Tests.cs" />
     <Compile Include="Model\DefaultModelHandler.Tests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/test/Microsoft.Restier.Core.Tests/Model/ConventionBasedApiModelBuilder.Tests.cs
+++ b/test/Microsoft.Restier.Core.Tests/Model/ConventionBasedApiModelBuilder.Tests.cs
@@ -208,9 +208,9 @@ namespace Microsoft.Restier.Core.Tests.Model
                 .IgnoreProperty("Invisible");
         }
 
-        protected override ApiBuilder ConfigureApiBuilder(ApiBuilder builder)
+        protected override ApiBuilder ConfigureApi(ApiBuilder builder)
         {
-            return base.ConfigureApiBuilder(builder)
+            return base.ConfigureApi(builder)
                 .AddHookHandler<IModelBuilder>(new TestModelBuilder());
         }
     }
@@ -255,9 +255,9 @@ namespace Microsoft.Restier.Core.Tests.Model
         public IQueryable<Person> People { get; set; }
         public IQueryable<Order> Orders { get; set; }
 
-        protected override ApiBuilder ConfigureApiBuilder(ApiBuilder builder)
+        protected override ApiBuilder ConfigureApi(ApiBuilder builder)
         {
-            return base.ConfigureApiBuilder(builder)
+            return base.ConfigureApi(builder)
                 .AddHookHandler<IModelBuilder>(new TestModelBuilder());
         }
     }
@@ -266,9 +266,9 @@ namespace Microsoft.Restier.Core.Tests.Model
     {
         public IQueryable<Customer> VipCustomers { get; set; }
 
-        protected override ApiBuilder ConfigureApiBuilder(ApiBuilder builder)
+        protected override ApiBuilder ConfigureApi(ApiBuilder builder)
         {
-            return base.ConfigureApiBuilder(builder)
+            return base.ConfigureApi(builder)
                 .AddHookHandler<IModelBuilder>(new TestModelBuilder());
         }
     }
@@ -284,9 +284,9 @@ namespace Microsoft.Restier.Core.Tests.Model
         public IQueryable<Customer> Customers { get; set; }
         public Customer Me2 { get; set; }
 
-        protected override ApiBuilder ConfigureApiBuilder(ApiBuilder builder)
+        protected override ApiBuilder ConfigureApi(ApiBuilder builder)
         {
-            return base.ConfigureApiBuilder(builder)
+            return base.ConfigureApi(builder)
                 .AddHookHandler<IModelBuilder>(new TestModelBuilder());
         }
     }

--- a/test/Microsoft.Restier.Core.Tests/Model/ConventionBasedApiModelBuilder.Tests.cs
+++ b/test/Microsoft.Restier.Core.Tests/Model/ConventionBasedApiModelBuilder.Tests.cs
@@ -179,9 +179,9 @@ namespace Microsoft.Restier.Core.Tests.Model
             get { return base.ApiContext; }
         }
 
-        protected override ApiConfiguration CreateApiConfiguration()
+        protected override ApiConfiguration CreateApiConfiguration(ApiBuilder builder)
         {
-            return base.CreateApiConfiguration()
+            return base.CreateApiConfiguration(builder)
                 .IgnoreProperty("ApiConfiguration")
                 .IgnoreProperty("ApiContext");
         }
@@ -202,11 +202,16 @@ namespace Microsoft.Restier.Core.Tests.Model
         public Person Me { get; set; }
         public IQueryable<Person> Invisible { get; set; }
 
-        protected override ApiConfiguration CreateApiConfiguration()
+        protected override ApiConfiguration CreateApiConfiguration(ApiBuilder builder)
         {
-            return base.CreateApiConfiguration()
-                .AddHookHandler<IModelBuilder>(new TestModelBuilder())
+            return base.CreateApiConfiguration(builder)
                 .IgnoreProperty("Invisible");
+        }
+
+        protected override ApiBuilder ConfigureApiBuilder(ApiBuilder builder)
+        {
+            return base.ConfigureApiBuilder(builder)
+                .AddHookHandler<IModelBuilder>(new TestModelBuilder());
         }
     }
 
@@ -234,9 +239,9 @@ namespace Microsoft.Restier.Core.Tests.Model
 
     public class ApiD : ApiC
     {
-        protected override ApiConfiguration CreateApiConfiguration()
+        protected override ApiConfiguration CreateApiConfiguration(ApiBuilder builder)
         {
-            return base.CreateApiConfiguration().IgnoreProperty("People");
+            return base.CreateApiConfiguration(builder).IgnoreProperty("People");
         }
     }
 
@@ -250,9 +255,9 @@ namespace Microsoft.Restier.Core.Tests.Model
         public IQueryable<Person> People { get; set; }
         public IQueryable<Order> Orders { get; set; }
 
-        protected override ApiConfiguration CreateApiConfiguration()
+        protected override ApiBuilder ConfigureApiBuilder(ApiBuilder builder)
         {
-            return base.CreateApiConfiguration()
+            return base.ConfigureApiBuilder(builder)
                 .AddHookHandler<IModelBuilder>(new TestModelBuilder());
         }
     }
@@ -261,9 +266,9 @@ namespace Microsoft.Restier.Core.Tests.Model
     {
         public IQueryable<Customer> VipCustomers { get; set; }
 
-        protected override ApiConfiguration CreateApiConfiguration()
+        protected override ApiBuilder ConfigureApiBuilder(ApiBuilder builder)
         {
-            return base.CreateApiConfiguration()
+            return base.ConfigureApiBuilder(builder)
                 .AddHookHandler<IModelBuilder>(new TestModelBuilder());
         }
     }
@@ -279,9 +284,9 @@ namespace Microsoft.Restier.Core.Tests.Model
         public IQueryable<Customer> Customers { get; set; }
         public Customer Me2 { get; set; }
 
-        protected override ApiConfiguration CreateApiConfiguration()
+        protected override ApiBuilder ConfigureApiBuilder(ApiBuilder builder)
         {
-            return base.CreateApiConfiguration()
+            return base.ConfigureApiBuilder(builder)
                 .AddHookHandler<IModelBuilder>(new TestModelBuilder());
         }
     }

--- a/test/Microsoft.Restier.Core.Tests/Model/DefaultModelHandler.Tests.cs
+++ b/test/Microsoft.Restier.Core.Tests/Model/DefaultModelHandler.Tests.cs
@@ -66,12 +66,12 @@ namespace Microsoft.Restier.Core.Tests.Model
         [Fact]
         public async Task GetModelUsingDefaultModelHandler()
         {
-            var configuration = new ApiConfiguration();
-            configuration.AddHookHandler<IModelBuilder>(new TestModelProducer());
-            configuration.AddHookHandler<IModelBuilder>(new TestModelExtender(2));
-            configuration.AddHookHandler<IModelBuilder>(new TestModelExtender(3));
+            var builder = new ApiBuilder();
+            builder.AddHookHandler<IModelBuilder>(new TestModelProducer());
+            builder.AddHookHandler<IModelBuilder>(new TestModelExtender(2));
+            builder.AddHookHandler<IModelBuilder>(new TestModelExtender(3));
 
-            configuration.EnsureCommitted();
+            var configuration = builder.Build();
             var context = new ApiContext(configuration);
 
             var model = await Api.GetModelAsync(context);

--- a/test/Microsoft.Restier.EntityFramework7.Tests/DateTests.cs
+++ b/test/Microsoft.Restier.EntityFramework7.Tests/DateTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Restier.EntityFramework.Tests
             {
                 dynamic newObj = new ExpandoObject();
                 newObj.DateProperty = "2016-01-04";
-                newObj.DTProperty = DateTime.Now;
+                newObj.DTProperty = DateTime.UtcNow;
                 newObj.DTOProperty = DateTimeOffset.Now;
                 newObj.TODProperty = "08:09:10";
                 newObj.TSProperty = "PT4H12M";
@@ -81,7 +81,7 @@ namespace Microsoft.Restier.EntityFramework.Tests
             {
                 dynamic newObj = new ExpandoObject();
                 newObj.DateProperty = "2016-01-04";
-                newObj.DTProperty = DateTime.Now;
+                newObj.DTProperty = DateTime.UtcNow;
                 newObj.DTOProperty = DateTimeOffset.Now;
                 newObj.RowId = 1024;
                 newObj.TODProperty = "08:09:10";
@@ -142,7 +142,7 @@ namespace Microsoft.Restier.EntityFramework.Tests
                 ctx.Add(new DateItem()
                 {
                     DateProperty = DateTime.Now,
-                    DTProperty = DateTime.Now,
+                    DTProperty = DateTime.UtcNow,
                     DTOProperty = DateTimeOffset.Now,
                     RowId = rowId,
                     TODProperty = TimeOfDay.Now,

--- a/test/Microsoft.Restier.EntityFramework7.Tests/Microsoft.Restier.EntityFramework7.Tests.csproj
+++ b/test/Microsoft.Restier.EntityFramework7.Tests/Microsoft.Restier.EntityFramework7.Tests.csproj
@@ -139,7 +139,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.OData, Version=5.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.OData.5.9.0-Nightly160127\lib\net45\System.Web.OData.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.OData.5.9.0-Nightly160216\lib\net45\System.Web.OData.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/test/Microsoft.Restier.EntityFramework7.Tests/Microsoft.Restier.EntityFramework7.Tests.csproj
+++ b/test/Microsoft.Restier.EntityFramework7.Tests/Microsoft.Restier.EntityFramework7.Tests.csproj
@@ -94,16 +94,16 @@
       <HintPath>..\..\packages\Microsoft.Framework.Primitives.1.0.0-beta8\lib\net45\Microsoft.Framework.Primitives.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Core, Version=6.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.OData.Core.6.13.0\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Core.dll</HintPath>
+    <Reference Include="Microsoft.OData.Core, Version=6.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.OData.Core.6.15.0-beta\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=6.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.OData.Edm.6.13.0\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Edm.dll</HintPath>
+    <Reference Include="Microsoft.OData.Edm, Version=6.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.OData.Edm.6.15.0-beta\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Edm.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Spatial, Version=6.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Spatial.6.13.0\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.Spatial.dll</HintPath>
+    <Reference Include="Microsoft.Spatial, Version=6.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Spatial.6.15.0-beta\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -138,8 +138,8 @@
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.2\lib\net45\System.Web.Http.WebHost.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Web.OData, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.OData.5.7.0\lib\net45\System.Web.OData.dll</HintPath>
+    <Reference Include="System.Web.OData, Version=5.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.OData.5.9.0-Nightly160127\lib\net45\System.Web.OData.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/test/Microsoft.Restier.EntityFramework7.Tests/app.config
+++ b/test/Microsoft.Restier.EntityFramework7.Tests/app.config
@@ -6,6 +6,18 @@
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.1.37.0" newVersion="1.1.37.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.OData.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.15.0.0" newVersion="6.15.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.OData.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.13.0.0" newVersion="6.13.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Spatial" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.15.0.0" newVersion="6.15.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/test/Microsoft.Restier.EntityFramework7.Tests/packages.config
+++ b/test/Microsoft.Restier.EntityFramework7.Tests/packages.config
@@ -5,7 +5,7 @@
   <package id="EntityFramework.Relational" version="7.0.0-beta8" targetFramework="net451" />
   <package id="EntityFramework.SqlServer" version="7.0.0-beta8" targetFramework="net451" />
   <package id="Ix-Async" version="1.2.5" targetFramework="net451" />
-  <package id="Microsoft.AspNet.OData" version="5.9.0-Nightly160127" targetFramework="net451" />
+  <package id="Microsoft.AspNet.OData" version="5.9.0-Nightly160216" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi" version="5.2.2" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.2" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.2" targetFramework="net451" />

--- a/test/Microsoft.Restier.EntityFramework7.Tests/packages.config
+++ b/test/Microsoft.Restier.EntityFramework7.Tests/packages.config
@@ -5,7 +5,7 @@
   <package id="EntityFramework.Relational" version="7.0.0-beta8" targetFramework="net451" />
   <package id="EntityFramework.SqlServer" version="7.0.0-beta8" targetFramework="net451" />
   <package id="Ix-Async" version="1.2.5" targetFramework="net451" />
-  <package id="Microsoft.AspNet.OData" version="5.7.0" targetFramework="net451" />
+  <package id="Microsoft.AspNet.OData" version="5.9.0-Nightly160127" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi" version="5.2.2" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.2" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.2" targetFramework="net451" />
@@ -21,9 +21,9 @@
   <package id="Microsoft.Framework.Logging.Abstractions" version="1.0.0-beta8" targetFramework="net451" />
   <package id="Microsoft.Framework.OptionsModel" version="1.0.0-beta8" targetFramework="net451" />
   <package id="Microsoft.Framework.Primitives" version="1.0.0-beta8" targetFramework="net451" />
-  <package id="Microsoft.OData.Core" version="6.13.0" targetFramework="net451" />
-  <package id="Microsoft.OData.Edm" version="6.13.0" targetFramework="net451" />
-  <package id="Microsoft.Spatial" version="6.13.0" targetFramework="net451" />
+  <package id="Microsoft.OData.Core" version="6.15.0-beta" targetFramework="net451" />
+  <package id="Microsoft.OData.Edm" version="6.15.0-beta" targetFramework="net451" />
+  <package id="Microsoft.Spatial" version="6.15.0-beta" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net451" />
   <package id="Remotion.Linq" version="2.0.0" targetFramework="net451" />
   <package id="System.Collections" version="4.0.0" targetFramework="net451" />

--- a/test/Microsoft.Restier.Samples.Northwind.EF7.Tests/App.config
+++ b/test/Microsoft.Restier.Samples.Northwind.EF7.Tests/App.config
@@ -21,15 +21,15 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.OData.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.12.0.0" newVersion="6.12.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.13.0.0" newVersion="6.13.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.OData.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.12.0.0" newVersion="6.12.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.15.0.0" newVersion="6.15.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Spatial" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.12.0.0" newVersion="6.12.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.15.0.0" newVersion="6.15.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />

--- a/test/Microsoft.Restier.Samples.Northwind.EF7.Tests/Microsoft.Restier.Samples.Northwind.EF7.Tests.csproj
+++ b/test/Microsoft.Restier.Samples.Northwind.EF7.Tests/Microsoft.Restier.Samples.Northwind.EF7.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -17,6 +18,8 @@
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -141,8 +144,16 @@
       <HintPath>..\..\packages\Microsoft.AspNet.OData.5.9.0-Nightly160127\lib\net45\System.Web.OData.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit, Version=1.9.2.1705, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\Packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -208,7 +219,9 @@
     <None Include="App.config">
       <SubType>Designer</SubType>
     </None>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\Microsoft.Restier.Samples.Northwind.Tests\Baselines\TestBatch.txt">
@@ -268,6 +281,12 @@
   </Choose>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/test/Microsoft.Restier.Samples.Northwind.EF7.Tests/Microsoft.Restier.Samples.Northwind.EF7.Tests.csproj
+++ b/test/Microsoft.Restier.Samples.Northwind.EF7.Tests/Microsoft.Restier.Samples.Northwind.EF7.Tests.csproj
@@ -93,16 +93,16 @@
       <HintPath>..\..\packages\Microsoft.Framework.Primitives.1.0.0-beta8\lib\net45\Microsoft.Framework.Primitives.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Core, Version=6.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\Packages\Microsoft.OData.Core.6.13.0\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Core.dll</HintPath>
+    <Reference Include="Microsoft.OData.Core, Version=6.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.OData.Core.6.15.0-beta\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=6.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\Packages\Microsoft.OData.Edm.6.13.0\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Edm.dll</HintPath>
+    <Reference Include="Microsoft.OData.Edm, Version=6.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.OData.Edm.6.15.0-beta\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Edm.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Spatial, Version=6.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\Packages\Microsoft.Spatial.6.13.0\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.Spatial.dll</HintPath>
+    <Reference Include="Microsoft.Spatial, Version=6.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Spatial.6.15.0-beta\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -137,8 +137,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.2\lib\net45\System.Web.Http.WebHost.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.OData, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\Packages\Microsoft.AspNet.OData.5.7.0\lib\net45\System.Web.OData.dll</HintPath>
+    <Reference Include="System.Web.OData, Version=5.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.OData.5.9.0-Nightly160127\lib\net45\System.Web.OData.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="xunit, Version=1.9.2.1705, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">

--- a/test/Microsoft.Restier.Samples.Northwind.EF7.Tests/Microsoft.Restier.Samples.Northwind.EF7.Tests.csproj
+++ b/test/Microsoft.Restier.Samples.Northwind.EF7.Tests/Microsoft.Restier.Samples.Northwind.EF7.Tests.csproj
@@ -141,7 +141,7 @@
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.2\lib\net45\System.Web.Http.WebHost.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.OData, Version=5.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.OData.5.9.0-Nightly160127\lib\net45\System.Web.OData.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.OData.5.9.0-Nightly160216\lib\net45\System.Web.OData.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">

--- a/test/Microsoft.Restier.Samples.Northwind.EF7.Tests/packages.config
+++ b/test/Microsoft.Restier.Samples.Northwind.EF7.Tests/packages.config
@@ -26,4 +26,8 @@
   <package id="Remotion.Linq" version="2.0.0" targetFramework="net451" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net451" />
   <package id="xunit" version="2.0.0" targetFramework="net451" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net451" />
+  <package id="xunit.assert" version="2.0.0" targetFramework="net451" />
+  <package id="xunit.core" version="2.0.0" targetFramework="net451" />
+  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net451" />
 </packages>

--- a/test/Microsoft.Restier.Samples.Northwind.EF7.Tests/packages.config
+++ b/test/Microsoft.Restier.Samples.Northwind.EF7.Tests/packages.config
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EntityFramework.Core" version="7.0.0-beta8" targetFramework="net451" />
   <package id="EntityFramework.Relational" version="7.0.0-beta8" targetFramework="net451" />
   <package id="EntityFramework.SqlServer" version="7.0.0-beta8" targetFramework="net451" />
   <package id="Ix-Async" version="1.2.5" targetFramework="net451" />
-  <package id="Microsoft.AspNet.OData" version="5.7.0" targetFramework="net451" />
+  <package id="Microsoft.AspNet.OData" version="5.9.0-Nightly160127" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.2" targetFramework="net45" />
@@ -19,11 +19,11 @@
   <package id="Microsoft.Framework.Logging.Abstractions" version="1.0.0-beta8" targetFramework="net451" />
   <package id="Microsoft.Framework.OptionsModel" version="1.0.0-beta8" targetFramework="net451" />
   <package id="Microsoft.Framework.Primitives" version="1.0.0-beta8" targetFramework="net451" />
-  <package id="Microsoft.OData.Core" version="6.13.0" targetFramework="net451" />
-  <package id="Microsoft.OData.Edm" version="6.13.0" targetFramework="net451" />
-  <package id="Microsoft.Spatial" version="6.13.0" targetFramework="net451" />
+  <package id="Microsoft.OData.Core" version="6.15.0-beta" targetFramework="net451" />
+  <package id="Microsoft.OData.Edm" version="6.15.0-beta" targetFramework="net451" />
+  <package id="Microsoft.Spatial" version="6.15.0-beta" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
   <package id="Remotion.Linq" version="2.0.0" targetFramework="net451" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net451" />
-  <package id="xunit" version="1.9.2" targetFramework="net451" />
+  <package id="xunit" version="2.0.0" targetFramework="net451" />
 </packages>

--- a/test/Microsoft.Restier.Samples.Northwind.EF7.Tests/packages.config
+++ b/test/Microsoft.Restier.Samples.Northwind.EF7.Tests/packages.config
@@ -4,7 +4,7 @@
   <package id="EntityFramework.Relational" version="7.0.0-beta8" targetFramework="net451" />
   <package id="EntityFramework.SqlServer" version="7.0.0-beta8" targetFramework="net451" />
   <package id="Ix-Async" version="1.2.5" targetFramework="net451" />
-  <package id="Microsoft.AspNet.OData" version="5.9.0-Nightly160127" targetFramework="net451" />
+  <package id="Microsoft.AspNet.OData" version="5.9.0-Nightly160216" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.2" targetFramework="net45" />

--- a/test/Microsoft.Restier.Samples.Northwind.Tests/Microsoft.Restier.Samples.Northwind.Tests.csproj
+++ b/test/Microsoft.Restier.Samples.Northwind.Tests/Microsoft.Restier.Samples.Northwind.Tests.csproj
@@ -77,7 +77,7 @@
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.2\lib\net45\System.Web.Http.WebHost.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.OData, Version=5.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.OData.5.9.0-Nightly160127\lib\net45\System.Web.OData.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.OData.5.9.0-Nightly160216\lib\net45\System.Web.OData.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">

--- a/test/Microsoft.Restier.Samples.Northwind.Tests/packages.config
+++ b/test/Microsoft.Restier.Samples.Northwind.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EntityFramework" version="6.1.1" targetFramework="net45" />
-  <package id="Microsoft.AspNet.OData" version="5.9.0-Nightly160127" targetFramework="net45" />
+  <package id="Microsoft.AspNet.OData" version="5.9.0-Nightly160216" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.2" targetFramework="net45" />

--- a/test/Microsoft.Restier.TestCommon/PublicApi.bsl
+++ b/test/Microsoft.Restier.TestCommon/PublicApi.bsl
@@ -2,6 +2,13 @@ public interface Microsoft.Restier.Core.IApi : IDisposable {
 	Microsoft.Restier.Core.ApiContext Context  { public abstract get; }
 }
 
+[
+CLSCompliantAttribute(),
+]
+public interface Microsoft.Restier.Core.IApiScopeFactory {
+	Microsoft.Framework.DependencyInjection.IServiceScope CreateApiScope ()
+}
+
 public interface Microsoft.Restier.Core.IDelegateHookHandler`1 {
 	T InnerHandler  { public abstract get; public abstract set; }
 }
@@ -16,7 +23,16 @@ public abstract class Microsoft.Restier.Core.ApiBase : IDisposable, IApi {
 	Microsoft.Restier.Core.ApiContext ApiContext  { protected get; }
 	bool IsDisposed  { [CompilerGeneratedAttribute(),]protected get; }
 
-	protected virtual Microsoft.Restier.Core.ApiConfiguration CreateApiConfiguration ()
+	[
+	CLSCompliantAttribute(),
+	]
+	protected virtual Microsoft.Restier.Core.ApiBuilder ConfigureApiBuilder (Microsoft.Restier.Core.ApiBuilder builder)
+
+	[
+	CLSCompliantAttribute(),
+	]
+	protected virtual Microsoft.Restier.Core.ApiConfiguration CreateApiConfiguration (Microsoft.Restier.Core.ApiBuilder builder)
+
 	protected virtual Microsoft.Restier.Core.ApiContext CreateApiContext (Microsoft.Restier.Core.ApiConfiguration configuration)
 	public virtual void Dispose ()
 	protected virtual void Dispose (bool disposing)
@@ -30,10 +46,20 @@ SerializableAttribute(),
 public abstract class Microsoft.Restier.Core.ApiConfiguratorAttribute : System.Attribute, _Attribute {
 	protected ApiConfiguratorAttribute ()
 
+	[
+	CLSCompliantAttribute(),
+	]
+	public static void ApplyApiBuilder (System.Type type, Microsoft.Restier.Core.ApiBuilder builder)
+
 	public static void ApplyConfiguration (System.Type type, Microsoft.Restier.Core.ApiConfiguration configuration)
 	public static void ApplyDisposal (System.Type type, object instance, Microsoft.Restier.Core.ApiContext context)
 	public static void ApplyInitialization (System.Type type, object instance, Microsoft.Restier.Core.ApiContext context)
 	public virtual void Configure (Microsoft.Restier.Core.ApiConfiguration configuration, System.Type type)
+	[
+	CLSCompliantAttribute(),
+	]
+	public virtual void ConfigureBuilder (Microsoft.Restier.Core.ApiBuilder builder, System.Type type)
+
 	public virtual void Dispose (Microsoft.Restier.Core.ApiContext context, System.Type type, object instance)
 	public virtual void Initialize (Microsoft.Restier.Core.ApiContext context, System.Type type, object instance)
 }
@@ -104,6 +130,87 @@ public sealed class Microsoft.Restier.Core.Api {
 }
 
 [
+CLSCompliantAttribute(),
+ExtensionAttribute(),
+]
+public sealed class Microsoft.Restier.Core.ApiBuilderExtensions {
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.Restier.Core.ApiBuilder AddContributor (Microsoft.Restier.Core.ApiBuilder obj, ApiServiceContributor`1 contributor)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.Restier.Core.ApiBuilder AddHookHandler (Microsoft.Restier.Core.ApiBuilder obj, T handler)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.Restier.Core.ApiBuilder AddInstance (Microsoft.Restier.Core.ApiBuilder obj, T instance)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.Restier.Core.ApiConfiguration Build (Microsoft.Restier.Core.ApiBuilder obj, params System.Func`2[[Microsoft.Restier.Core.ApiBuilder],[System.IServiceProvider]] serviceProviderFactory)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static T BuildApiServiceChain (System.IServiceProvider obj)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.Restier.Core.ApiBuilder ChainPrevious (Microsoft.Restier.Core.ApiBuilder obj, Func`2 factory)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.Restier.Core.ApiBuilder ChainPrevious (Microsoft.Restier.Core.ApiBuilder obj, Func`3 factory)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static bool HasHookHandler (Microsoft.Restier.Core.ApiBuilder obj)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.Restier.Core.ApiBuilder MakeScoped (Microsoft.Restier.Core.ApiBuilder obj)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.Restier.Core.ApiBuilder MakeSingleton (Microsoft.Restier.Core.ApiBuilder obj)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.Restier.Core.ApiBuilder MakeTransient (Microsoft.Restier.Core.ApiBuilder obj)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.Restier.Core.ApiBuilder TryUseContextApiScope (Microsoft.Restier.Core.ApiBuilder obj)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.Restier.Core.ApiBuilder TryUseSharedApiScope (Microsoft.Restier.Core.ApiBuilder obj)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.Restier.Core.ApiBuilder UseContextApiScope (Microsoft.Restier.Core.ApiBuilder obj)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.Restier.Core.ApiBuilder UseSharedApiScope (Microsoft.Restier.Core.ApiBuilder obj)
+}
+
+[
 ExtensionAttribute(),
 ]
 public sealed class Microsoft.Restier.Core.ApiConfigurationExtensions {
@@ -124,11 +231,11 @@ public sealed class Microsoft.Restier.Core.ApiData {
 }
 
 public class Microsoft.Restier.Core.ApiConfiguration : Microsoft.Restier.Core.PropertyBag {
-	public ApiConfiguration ()
+	public ApiConfiguration (System.IServiceProvider serviceProvider)
 
-	bool IsCommitted  { [CompilerGeneratedAttribute(),]public get; }
+	bool IsCommitted  { public get; }
+	System.IServiceProvider ServiceProvider  { public get; }
 
-	public Microsoft.Restier.Core.ApiConfiguration AddHookHandler (T handler)
 	public void EnsureCommitted ()
 	public T GetHookHandler ()
 }
@@ -137,6 +244,9 @@ public class Microsoft.Restier.Core.ApiContext : Microsoft.Restier.Core.Property
 	public ApiContext (Microsoft.Restier.Core.ApiConfiguration configuration)
 
 	Microsoft.Restier.Core.ApiConfiguration Configuration  { [CompilerGeneratedAttribute(),]public get; }
+	System.IServiceProvider ServiceProvider  { public get; }
+
+	public T GetApiService ()
 }
 
 public class Microsoft.Restier.Core.InvocationContext : Microsoft.Restier.Core.PropertyBag {
@@ -157,12 +267,34 @@ public class Microsoft.Restier.Core.PropertyBag {
 	public void SetProperty (string name, object value)
 }
 
+[
+CLSCompliantAttribute(),
+]
+public sealed class Microsoft.Restier.Core.ApiBuilder {
+	public ApiBuilder ()
+	public ApiBuilder (Microsoft.Framework.DependencyInjection.IServiceCollection services)
+
+	Microsoft.Framework.DependencyInjection.IServiceCollection Services  { [CompilerGeneratedAttribute(),]public get; }
+}
+
+public sealed class Microsoft.Restier.Core.ApiServiceContributor`1 : System.MulticastDelegate, ICloneable, ISerializable {
+	public ApiServiceContributor`1 (object object, System.IntPtr method)
+
+	public virtual System.IAsyncResult BeginInvoke (System.IServiceProvider serviceProvider, Func`1 next, System.AsyncCallback callback, object object)
+	public virtual T EndInvoke (System.IAsyncResult result)
+	public virtual T Invoke (System.IServiceProvider serviceProvider, Func`1 next)
+}
+
 public class Microsoft.Restier.EntityFramework.DbApi`1 : Microsoft.Restier.Core.ApiBase, IDisposable, IApi {
 	public DbApi`1 ()
 
 	T DbContext  { protected get; }
 
-	protected virtual Microsoft.Restier.Core.ApiConfiguration CreateApiConfiguration ()
+	[
+	CLSCompliantAttribute(),
+	]
+	protected virtual Microsoft.Restier.Core.ApiBuilder ConfigureApiBuilder (Microsoft.Restier.Core.ApiBuilder builder)
+
 	protected virtual Microsoft.Restier.Core.ApiContext CreateApiContext (Microsoft.Restier.Core.ApiConfiguration configuration)
 	protected virtual T CreateDbContext ()
 	protected virtual void Dispose (bool disposing)

--- a/test/Microsoft.Restier.TestCommon/PublicApi.bsl
+++ b/test/Microsoft.Restier.TestCommon/PublicApi.bsl
@@ -152,7 +152,12 @@ public sealed class Microsoft.Restier.Core.ApiBuilderExtensions {
 	[
 	ExtensionAttribute(),
 	]
-	public static Microsoft.Restier.Core.ApiConfiguration Build (Microsoft.Restier.Core.ApiBuilder obj, params System.Func`2[[Microsoft.Restier.Core.ApiBuilder],[System.IServiceProvider]] serviceProviderFactory)
+	public static Microsoft.Restier.Core.ApiConfiguration Build (Microsoft.Restier.Core.ApiBuilder obj)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.Restier.Core.ApiConfiguration Build (Microsoft.Restier.Core.ApiBuilder obj, System.Func`2[[Microsoft.Restier.Core.ApiBuilder],[System.IServiceProvider]] serviceProviderFactory)
 
 	[
 	ExtensionAttribute(),

--- a/test/Microsoft.Restier.TestCommon/PublicApi.bsl
+++ b/test/Microsoft.Restier.TestCommon/PublicApi.bsl
@@ -167,6 +167,11 @@ public sealed class Microsoft.Restier.Core.ApiBuilderExtensions {
 	[
 	ExtensionAttribute(),
 	]
+	public static Microsoft.Restier.Core.ApiBuilder ChainPrevious (Microsoft.Restier.Core.ApiBuilder obj)
+
+	[
+	ExtensionAttribute(),
+	]
 	public static Microsoft.Restier.Core.ApiBuilder ChainPrevious (Microsoft.Restier.Core.ApiBuilder obj, Func`2 factory)
 
 	[

--- a/test/Microsoft.Restier.TestCommon/PublicApi.bsl
+++ b/test/Microsoft.Restier.TestCommon/PublicApi.bsl
@@ -23,16 +23,8 @@ public abstract class Microsoft.Restier.Core.ApiBase : IDisposable, IApi {
 	Microsoft.Restier.Core.ApiContext ApiContext  { protected get; }
 	bool IsDisposed  { [CompilerGeneratedAttribute(),]protected get; }
 
-	[
-	CLSCompliantAttribute(),
-	]
-	protected virtual Microsoft.Restier.Core.ApiBuilder ConfigureApiBuilder (Microsoft.Restier.Core.ApiBuilder builder)
-
-	[
-	CLSCompliantAttribute(),
-	]
+	protected virtual Microsoft.Restier.Core.ApiBuilder ConfigureApi (Microsoft.Restier.Core.ApiBuilder builder)
 	protected virtual Microsoft.Restier.Core.ApiConfiguration CreateApiConfiguration (Microsoft.Restier.Core.ApiBuilder builder)
-
 	protected virtual Microsoft.Restier.Core.ApiContext CreateApiContext (Microsoft.Restier.Core.ApiConfiguration configuration)
 	public virtual void Dispose ()
 	protected virtual void Dispose (bool disposing)
@@ -46,20 +38,12 @@ SerializableAttribute(),
 public abstract class Microsoft.Restier.Core.ApiConfiguratorAttribute : System.Attribute, _Attribute {
 	protected ApiConfiguratorAttribute ()
 
-	[
-	CLSCompliantAttribute(),
-	]
 	public static void ApplyApiBuilder (System.Type type, Microsoft.Restier.Core.ApiBuilder builder)
-
 	public static void ApplyConfiguration (System.Type type, Microsoft.Restier.Core.ApiConfiguration configuration)
 	public static void ApplyDisposal (System.Type type, object instance, Microsoft.Restier.Core.ApiContext context)
 	public static void ApplyInitialization (System.Type type, object instance, Microsoft.Restier.Core.ApiContext context)
 	public virtual void Configure (Microsoft.Restier.Core.ApiConfiguration configuration, System.Type type)
-	[
-	CLSCompliantAttribute(),
-	]
-	public virtual void ConfigureBuilder (Microsoft.Restier.Core.ApiBuilder builder, System.Type type)
-
+	public virtual void ConfigureApi (Microsoft.Restier.Core.ApiBuilder builder, System.Type type)
 	public virtual void Dispose (Microsoft.Restier.Core.ApiContext context, System.Type type, object instance)
 	public virtual void Initialize (Microsoft.Restier.Core.ApiContext context, System.Type type, object instance)
 }
@@ -130,7 +114,6 @@ public sealed class Microsoft.Restier.Core.Api {
 }
 
 [
-CLSCompliantAttribute(),
 ExtensionAttribute(),
 ]
 public sealed class Microsoft.Restier.Core.ApiBuilderExtensions {
@@ -277,13 +260,16 @@ public class Microsoft.Restier.Core.PropertyBag {
 	public void SetProperty (string name, object value)
 }
 
-[
-CLSCompliantAttribute(),
-]
 public sealed class Microsoft.Restier.Core.ApiBuilder {
 	public ApiBuilder ()
+	[
+	CLSCompliantAttribute(),
+	]
 	public ApiBuilder (Microsoft.Framework.DependencyInjection.IServiceCollection services)
 
+	[
+	CLSCompliantAttribute(),
+	]
 	Microsoft.Framework.DependencyInjection.IServiceCollection Services  { [CompilerGeneratedAttribute(),]public get; }
 }
 
@@ -300,11 +286,7 @@ public class Microsoft.Restier.EntityFramework.DbApi`1 : Microsoft.Restier.Core.
 
 	T DbContext  { protected get; }
 
-	[
-	CLSCompliantAttribute(),
-	]
-	protected virtual Microsoft.Restier.Core.ApiBuilder ConfigureApiBuilder (Microsoft.Restier.Core.ApiBuilder builder)
-
+	protected virtual Microsoft.Restier.Core.ApiBuilder ConfigureApi (Microsoft.Restier.Core.ApiBuilder builder)
 	protected virtual Microsoft.Restier.Core.ApiContext CreateApiContext (Microsoft.Restier.Core.ApiConfiguration configuration)
 	protected virtual T CreateDbContext ()
 	protected virtual void Dispose (bool disposing)

--- a/test/Microsoft.Restier.WebApi.Test/ExceptionHandlerTests.cs
+++ b/test/Microsoft.Restier.WebApi.Test/ExceptionHandlerTests.cs
@@ -31,9 +31,9 @@ namespace Microsoft.Restier.WebApi.Test
 
         private class ExcApi : StoreApi
         {
-            protected override ApiConfiguration CreateApiConfiguration()
+            protected override ApiBuilder ConfigureApiBuilder(ApiBuilder builder)
             {
-                return base.CreateApiConfiguration()
+                return base.ConfigureApiBuilder(builder)
                     .AddHookHandler<IQueryExpressionSourcer>(new FakeSourcer());
             }
         }

--- a/test/Microsoft.Restier.WebApi.Test/ExceptionHandlerTests.cs
+++ b/test/Microsoft.Restier.WebApi.Test/ExceptionHandlerTests.cs
@@ -31,9 +31,9 @@ namespace Microsoft.Restier.WebApi.Test
 
         private class ExcApi : StoreApi
         {
-            protected override ApiBuilder ConfigureApiBuilder(ApiBuilder builder)
+            protected override ApiBuilder ConfigureApi(ApiBuilder builder)
             {
-                return base.ConfigureApiBuilder(builder)
+                return base.ConfigureApi(builder)
                     .AddHookHandler<IQueryExpressionSourcer>(new FakeSourcer());
             }
         }

--- a/test/Microsoft.Restier.WebApi.Test/FallbackTests.cs
+++ b/test/Microsoft.Restier.WebApi.Test/FallbackTests.cs
@@ -94,9 +94,9 @@ namespace Microsoft.Restier.WebApi.Test
 
     internal class FallbackApi : ApiBase
     {
-        protected override ApiBuilder ConfigureApiBuilder(ApiBuilder builder)
+        protected override ApiBuilder ConfigureApi(ApiBuilder builder)
         {
-            builder = base.ConfigureApiBuilder(builder);
+            builder = base.ConfigureApi(builder);
             builder.AddHookHandler<IModelBuilder>(new TestModelProducer(FallbackModel.Model));
             builder.AddHookHandler<IModelMapper>(new FallbackModelMapper());
             builder.AddHookHandler<IQueryExpressionSourcer>(new FallbackQueryExpressionSourcer());

--- a/test/Microsoft.Restier.WebApi.Test/FallbackTests.cs
+++ b/test/Microsoft.Restier.WebApi.Test/FallbackTests.cs
@@ -94,13 +94,13 @@ namespace Microsoft.Restier.WebApi.Test
 
     internal class FallbackApi : ApiBase
     {
-        protected override ApiConfiguration CreateApiConfiguration()
+        protected override ApiBuilder ConfigureApiBuilder(ApiBuilder builder)
         {
-            var configuration = base.CreateApiConfiguration();
-            configuration.AddHookHandler<IModelBuilder>(new TestModelProducer(FallbackModel.Model));
-            configuration.AddHookHandler<IModelMapper>(new FallbackModelMapper());
-            configuration.AddHookHandler<IQueryExpressionSourcer>(new FallbackQueryExpressionSourcer());
-            return configuration;
+            builder = base.ConfigureApiBuilder(builder);
+            builder.AddHookHandler<IModelBuilder>(new TestModelProducer(FallbackModel.Model));
+            builder.AddHookHandler<IModelMapper>(new FallbackModelMapper());
+            builder.AddHookHandler<IQueryExpressionSourcer>(new FallbackQueryExpressionSourcer());
+            return builder;
         }
 
         public IQueryable<Order> PreservedOrders

--- a/test/Microsoft.Restier.WebApi.Test/Microsoft.Restier.WebApi.Test.csproj
+++ b/test/Microsoft.Restier.WebApi.Test/Microsoft.Restier.WebApi.Test.csproj
@@ -64,7 +64,7 @@
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.2.2\lib\net45\System.Web.Http.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.OData, Version=5.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.OData.5.9.0-Nightly160127\lib\net45\System.Web.OData.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.OData.5.9.0-Nightly160216\lib\net45\System.Web.OData.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">

--- a/test/Microsoft.Restier.WebApi.Test/StoreApi.cs
+++ b/test/Microsoft.Restier.WebApi.Test/StoreApi.cs
@@ -34,15 +34,15 @@ namespace Microsoft.Restier.WebApi.Test
 
     internal class StoreApi : ApiBase
     {
-        protected override ApiConfiguration CreateApiConfiguration()
+        protected override ApiBuilder ConfigureApiBuilder(ApiBuilder builder)
         {
-            var configuration = base.CreateApiConfiguration();
-            configuration.AddHookHandler<IModelBuilder>(new TestModelProducer(StoreModel.Model));
-            configuration.AddHookHandler<IModelMapper>(new TestModelMapper());
-            configuration.AddHookHandler<IQueryExpressionSourcer>(new TestQueryExpressionSourcer());
-            configuration.AddHookHandler<IChangeSetPreparer>(new TestChangeSetPreparer());
-            configuration.AddHookHandler<ISubmitExecutor>(new TestSubmitExecutor());
-            return configuration;
+            builder = base.ConfigureApiBuilder(builder);
+            builder.AddHookHandler<IModelBuilder>(new TestModelProducer(StoreModel.Model));
+            builder.AddHookHandler<IModelMapper>(new TestModelMapper());
+            builder.AddHookHandler<IQueryExpressionSourcer>(new TestQueryExpressionSourcer());
+            builder.AddHookHandler<IChangeSetPreparer>(new TestChangeSetPreparer());
+            builder.AddHookHandler<ISubmitExecutor>(new TestSubmitExecutor());
+            return builder;
         }
     }
 

--- a/test/Microsoft.Restier.WebApi.Test/StoreApi.cs
+++ b/test/Microsoft.Restier.WebApi.Test/StoreApi.cs
@@ -34,9 +34,9 @@ namespace Microsoft.Restier.WebApi.Test
 
     internal class StoreApi : ApiBase
     {
-        protected override ApiBuilder ConfigureApiBuilder(ApiBuilder builder)
+        protected override ApiBuilder ConfigureApi(ApiBuilder builder)
         {
-            builder = base.ConfigureApiBuilder(builder);
+            builder = base.ConfigureApi(builder);
             builder.AddHookHandler<IModelBuilder>(new TestModelProducer(StoreModel.Model));
             builder.AddHookHandler<IModelMapper>(new TestModelMapper());
             builder.AddHookHandler<IQueryExpressionSourcer>(new TestQueryExpressionSourcer());

--- a/test/Microsoft.Restier.WebApi.Test/packages.config
+++ b/test/Microsoft.Restier.WebApi.Test/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.OData" version="5.9.0-Nightly160127" targetFramework="net45" />
+  <package id="Microsoft.AspNet.OData" version="5.9.0-Nightly160216" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.OData.Core" version="6.15.0-beta" targetFramework="net45" />

--- a/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Services.Trippin/Microsoft.Restier.WebApi.Test.Services.Trippin.csproj
+++ b/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Services.Trippin/Microsoft.Restier.WebApi.Test.Services.Trippin.csproj
@@ -131,7 +131,7 @@
       <HintPath>..\..\..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.2\lib\net45\System.Web.Http.WebHost.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.OData, Version=5.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.AspNet.OData.5.9.0-Nightly160127\lib\net45\System.Web.OData.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.AspNet.OData.5.9.0-Nightly160216\lib\net45\System.Web.OData.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Services.Trippin/packages.config
+++ b/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Services.Trippin/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EntityFramework" version="6.1.1" targetFramework="net45" />
-  <package id="Microsoft.AspNet.OData" version="5.9.0-Nightly160127" targetFramework="net45" />
+  <package id="Microsoft.AspNet.OData" version="5.9.0-Nightly160216" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.2" targetFramework="net45" />

--- a/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Services.TrippinInMemory/Microsoft.Restier.WebApi.Test.Services.TrippinInMemory.csproj
+++ b/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Services.TrippinInMemory/Microsoft.Restier.WebApi.Test.Services.TrippinInMemory.csproj
@@ -63,7 +63,7 @@
     <Reference Include="System.Web" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Web.OData, Version=5.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.AspNet.OData.5.9.0-Nightly160127\lib\net45\System.Web.OData.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.AspNet.OData.5.9.0-Nightly160216\lib\net45\System.Web.OData.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.Services" />

--- a/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Services.TrippinInMemory/Models/TrippinApi.cs
+++ b/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Services.TrippinInMemory/Models/TrippinApi.cs
@@ -118,9 +118,9 @@ namespace Microsoft.Restier.WebApi.Test.Services.TrippinInMemory
             get { return this.Source<Person>("People").Where(p => p.PersonId >= 2); }
         }
 
-        protected override ApiBuilder ConfigureApiBuilder(ApiBuilder builder)
+        protected override ApiBuilder ConfigureApi(ApiBuilder builder)
         {
-            return base.ConfigureApiBuilder(builder)
+            return base.ConfigureApi(builder)
                 .AddHookHandler<IModelBuilder>(new ModelBuilder());
         }
 

--- a/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Services.TrippinInMemory/Models/TrippinApi.cs
+++ b/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Services.TrippinInMemory/Models/TrippinApi.cs
@@ -118,9 +118,9 @@ namespace Microsoft.Restier.WebApi.Test.Services.TrippinInMemory
             get { return this.Source<Person>("People").Where(p => p.PersonId >= 2); }
         }
 
-        protected override ApiConfiguration CreateApiConfiguration()
+        protected override ApiBuilder ConfigureApiBuilder(ApiBuilder builder)
         {
-            return base.CreateApiConfiguration()
+            return base.ConfigureApiBuilder(builder)
                 .AddHookHandler<IModelBuilder>(new ModelBuilder());
         }
 

--- a/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Services.TrippinInMemory/packages.config
+++ b/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Services.TrippinInMemory/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.OData" version="5.9.0-Nightly160127" targetFramework="net45" />
+  <package id="Microsoft.AspNet.OData" version="5.9.0-Nightly160216" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi" version="5.2.2" targetFramework="net46" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.2" targetFramework="net46" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.2" targetFramework="net46" />


### PR DESCRIPTION
Use Micorsoft DI framework to replace current Dictionary<,> based service registration.
This is a relatively aggressive change, compared to my previous PR. There's an option 2 #286 pull request which is basically identical to the previous PR #264. It's up to you to make a choice.
In this change the main difference is that class **ApiBuilder** is added for API service registration, and later build an ApiConfiguration.
Pros:
- No **Committed** state for ApiConfiguration, it's committed once created. For now those related methods are not removed yet but they do nothing.
- ApiConfiguration itself is registered as a service and participate in DI. That means a descendant Api class could register some service which gets an ApiConfiguration injected on construction.

But of course, at the same time this change inevitably has broader impact to existing code.
- ApiConfiguration public interface changes, This breaks a lot of things, which of course are fixed with this change. But, any consumer out there may have a bigger chance to break, compared to option 2.