### PR TITLE
Microsoft.FX.DI integration [Option 2]

### DIFF
--- a/src/Microsoft.Restier.Core/Api.cs
+++ b/src/Microsoft.Restier.Core/Api.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Restier.Core
             var config = context.Configuration;
             if (config.Model == null)
             {
-                var builder = context.Configuration.GetHookHandler<IModelBuilder>();
+                var builder = context.GetApiService<IModelBuilder>();
                 if (builder != null)
                 {
                     config.Model = await builder.GetModelAsync(new InvocationContext(context), cancellationToken);
@@ -631,7 +631,7 @@ namespace Microsoft.Restier.Core
         {
             Type elementType = null;
 
-            var mapper = context.Configuration.GetHookHandler<IModelMapper>();
+            var mapper = context.GetApiService<IModelMapper>();
             if (mapper != null)
             {
                 if (namespaceName == null)

--- a/src/Microsoft.Restier.Core/ApiBase.cs
+++ b/src/Microsoft.Restier.Core/ApiBase.cs
@@ -156,6 +156,11 @@ namespace Microsoft.Restier.Core
         /// </param>
         protected virtual void Dispose(bool disposing)
         {
+            if (this.apiContext != null)
+            {
+                this.apiContext.DisposeScope();
+            }
+
             if (disposing)
             {
                 this.apiContext = null;

--- a/src/Microsoft.Restier.Core/ApiConfiguration.cs
+++ b/src/Microsoft.Restier.Core/ApiConfiguration.cs
@@ -4,12 +4,29 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Extensions;
 using Microsoft.OData.Edm;
 using Microsoft.Restier.Core.Properties;
 using Microsoft.Restier.Core.Query;
 
 namespace Microsoft.Restier.Core
 {
+    /// <summary>
+    /// A delegate which participate in service creation.
+    /// All registered contributors form a chain, and the last registered will be called first.
+    /// </summary>
+    /// <typeparam name="T">The service type.</typeparam>
+    /// <param name="serviceProvider">
+    /// The <see cref="IServiceProvider"/> to which this contributor call is registered.
+    /// </param>
+    /// <param name="next">
+    /// Return the result of the previous contributor on the chain.
+    /// </param>
+    /// <returns>A service instance of <typeparamref name="T"/>.</returns>
+    public delegate T ApiServiceContributor<T>(IServiceProvider serviceProvider, Func<T> next) where T : class;
+
     /// <summary>
     /// Represents a configuration that defines an API.
     /// </summary>
@@ -35,15 +52,53 @@ namespace Microsoft.Restier.Core
     /// </remarks>
     public class ApiConfiguration : PropertyBag
     {
-        private readonly IDictionary<Type, IHookHandler> hookHandlers =
-            new ConcurrentDictionary<Type, IHookHandler>();
+        private IServiceCollection services;
+
+        private IServiceProvider serviceProvider;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiConfiguration" /> class.
         /// </summary>
-        public ApiConfiguration()
+        public ApiConfiguration() : this(null)
         {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiConfiguration" /> class.
+        /// </summary>
+        /// <param name="services">A service collection containing service registrations.</param>
+        [CLSCompliant(false)]
+        public ApiConfiguration(IServiceCollection services)
+        {
+            if (services == null)
+            {
+                services = new ServiceCollection();
+            }
+
+            services.AddInstance<ApiConfiguration>(this);
+            this.services = services;
+            this.TryUseSharedApiScope();
+
             this.AddDefaultHookHandlers();
+        }
+
+        /// <summary>
+        /// Gets the <see cref="IServiceProvider"/> which contains all services of this
+        /// <see cref="ApiConfiguration"/>.
+        /// </summary>
+        public IServiceProvider ServiceProvider
+        {
+            get { return serviceProvider; }
+        }
+
+        /// <summary>
+        /// Gets the service collection containing service registrations with which to build
+        /// <see cref="ServiceProvider"/>.
+        /// </summary>
+        [CLSCompliant(false)]
+        public IServiceCollection Services
+        {
+            get { return services; }
         }
 
         /// <summary>
@@ -58,6 +113,14 @@ namespace Microsoft.Restier.Core
         /// </summary>
         public void EnsureCommitted()
         {
+            if (this.IsCommitted)
+            {
+                return;
+            }
+
+            this.serviceProvider = BuildServiceProvider();
+            this.services = null;
+
             this.IsCommitted = true;
         }
 
@@ -82,32 +145,204 @@ namespace Microsoft.Restier.Core
                 throw new InvalidOperationException(Resources.ShouldBeInterfaceType);
             }
 
-            var delegateHandler = handler as IDelegateHookHandler<T>;
-            if (delegateHandler != null)
+            // Since legacy hook handlers are registered with instance, they must have singleton lifetime.
+            // And so a singleton HookHandlerContributor is registered for each hook handler type, and it
+            // will cache the legacy handler chain once built.
+            if (!this.services.Any(sd => sd.ServiceType == typeof(LegacyHookHandler<T>)))
             {
-                delegateHandler.InnerHandler = this.GetHookHandler<T>();
+                T cached = null;
+                this.services.AddInstance<ApiServiceContributor<T>>((sp, next) =>
+                {
+                    return cached ?? (cached = HookHandlerType<T>.BuildLegacyHandlers(sp, next));
+                });
+
+                // Hook handlers have singleton lifetime by default, call Make... to change.
+                this.services.TryAddSingleton(typeof(T), ChainedService<T>.DefaultFactory);
             }
 
-            this.hookHandlers[typeof(T)] = handler;
+            this.services.AddInstance(new LegacyHookHandler<T>(handler));
+
             return this;
         }
 
         /// <summary>
-        /// Gets a hook handler instance.
+        /// Adds a service contributor, which has a chance to chain previously registered service instances.
         /// </summary>
-        /// <typeparam name="T">The hook handler interface.</typeparam>
-        /// <returns>The hook handler instance.</returns>
-        public T GetHookHandler<T>() where T : class, IHookHandler
+        /// <typeparam name="T">The service type.</typeparam>
+        /// <param name="contributor">An instance of <see cref="ApiServiceContributor{T}"/>.</param>
+        /// <returns>Current <see cref="ApiConfiguration"/></returns>
+        public ApiConfiguration AddContributor<T>(ApiServiceContributor<T> contributor) where T : class
         {
-            IHookHandler value;
-            this.hookHandlers.TryGetValue(typeof(T), out value);
-            return value as T;
+            Ensure.NotNull(contributor, nameof(contributor));
+
+            if (this.IsCommitted)
+            {
+                throw new InvalidOperationException(Resources.ApiConfigurationIsCommitted);
+            }
+
+            // Services have singleton lifetime by default, call Make... to change.
+            this.services.TryAddSingleton(typeof(T), ChainedService<T>.DefaultFactory);
+            this.services.AddInstance(contributor);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a service contributor, which has a chance to chain previously registered service instances.
+        /// </summary>
+        /// <typeparam name="T">The service type.</typeparam>
+        /// <param name="factory">
+        /// A factory method to create a new instance of service T, wrapping previous instance."/>.
+        /// </param>
+        /// <returns>Current <see cref="ApiConfiguration"/></returns>
+        public ApiConfiguration ChainPrevious<T>(Func<IServiceProvider, T, T> factory)
+            where T : class
+        {
+            Ensure.NotNull(factory, nameof(factory));
+            return AddContributor<T>((sp, next) => factory(sp, next()));
+        }
+
+        /// <summary>
+        /// Adds a service contributor, which has a chance to chain previously registered service instances.
+        /// </summary>
+        /// <typeparam name="T">The service type.</typeparam>
+        /// <param name="factory">
+        /// A factory method to create a new instance of service T, wrapping previous instance."/>.
+        /// </param>
+        /// <returns>Current <see cref="ApiConfiguration"/></returns>
+        public ApiConfiguration ChainPrevious<T>(Func<T, T> factory) where T : class
+        {
+            Ensure.NotNull(factory, nameof(factory));
+            return AddContributor<T>((sp, next) => factory(next()));
+        }
+
+        /// <summary>
+        /// Call this to make singleton lifetime of a service.
+        /// </summary>
+        /// <typeparam name="T">The service type.</typeparam>
+        /// <returns>Current <see cref="ApiConfiguration"/></returns>
+        public ApiConfiguration MakeSingleton<T>() where T : class
+        {
+            this.services.AddSingleton<T>(ChainedService<T>.DefaultFactory);
+            return this;
+        }
+
+        /// <summary>
+        /// Call this to make scoped lifetime of a service.
+        /// </summary>
+        /// <typeparam name="T">The service type.</typeparam>
+        /// <returns>Current <see cref="ApiConfiguration"/></returns>
+        public ApiConfiguration MakeScoped<T>() where T : class
+        {
+            this.services.AddScoped<T>(ChainedService<T>.DefaultFactory);
+            return this;
+        }
+
+        /// <summary>
+        /// Call this to make transient lifetime of a service.
+        /// </summary>
+        /// <typeparam name="T">The service type.</typeparam>
+        /// <returns>Current <see cref="ApiConfiguration"/></returns>
+        public ApiConfiguration MakeTransient<T>() where T : class
+        {
+            this.services.AddTransient<T>(ChainedService<T>.DefaultFactory);
+            return this;
+        }
+
+        /// <summary>
+        /// Gets a service instance.
+        /// </summary>
+        /// <typeparam name="T">The service type.</typeparam>
+        /// <returns>The service instance.</returns>
+        public T GetHookHandler<T>() where T : class
+        {
+            return this.serviceProvider.GetService<T>();
         }
         #endregion
+
+        /// <summary>
+        /// Override this to use your favorite DI container, as long as it has an IServiceProvider wrapper.
+        /// </summary>
+        /// <returns>The built <see cref="IServiceProvider"/>.</returns>
+        protected virtual IServiceProvider BuildServiceProvider()
+        {
+            return Services.BuildServiceProvider();
+        }
 
         private void AddDefaultHookHandlers()
         {
             this.AddHookHandler<IQueryExecutor>(DefaultQueryExecutor.Instance);
+        }
+
+        private static class ChainedService<T> where T : class
+        {
+            public static readonly Func<IServiceProvider, T> DefaultFactory = sp =>
+            {
+                var instances = sp.GetServices<ApiServiceContributor<T>>().Reverse();
+
+                using (var e = instances.GetEnumerator())
+                {
+                    Func<T> next = null;
+                    next = () =>
+                    {
+                        if (e.MoveNext())
+                        {
+                            return e.Current(sp, next);
+                        }
+
+                        return null;
+                    };
+
+                    return next();
+                }
+            };
+        }
+
+        private static class HookHandlerType<T> where T : class, IHookHandler
+        {
+            public static T BuildLegacyHandlers(IServiceProvider sp, Func<T> next)
+            {
+                var instances = sp.GetServices<LegacyHookHandler<T>>().Reverse();
+
+                using (var e = instances.GetEnumerator())
+                {
+                    if (!e.MoveNext())
+                    {
+                        return null;
+                    }
+
+                    T first = e.Current.Instance;
+                    T current = first;
+                    while (e.MoveNext())
+                    {
+                        var delegateHandler = current as IDelegateHookHandler<T>;
+                        if (delegateHandler == null)
+                        {
+                            return first;
+                        }
+
+                        delegateHandler.InnerHandler = current = e.Current.Instance;
+                    }
+
+                    var finalDelegate = current as IDelegateHookHandler<T>;
+                    if (finalDelegate != null)
+                    {
+                        finalDelegate.InnerHandler = next();
+                    }
+
+                    return first;
+                }
+            }
+        }
+
+        private class LegacyHookHandler<T> where T : class, IHookHandler
+        {
+            public LegacyHookHandler(T instance)
+            {
+                Instance = instance;
+            }
+
+            public T Instance { get; private set; }
         }
     }
 }

--- a/src/Microsoft.Restier.Core/ApiContext.cs
+++ b/src/Microsoft.Restier.Core/ApiContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Framework.DependencyInjection;
 using Microsoft.Restier.Core.Properties;
 
 namespace Microsoft.Restier.Core
@@ -16,6 +17,8 @@ namespace Microsoft.Restier.Core
     /// </remarks>
     public class ApiContext : PropertyBag
     {
+        private IServiceScope contextScope;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiContext" /> class.
         /// </summary>
@@ -31,11 +34,35 @@ namespace Microsoft.Restier.Core
             }
 
             this.Configuration = configuration;
+            this.contextScope = configuration.ServiceProvider.GetRequiredService<IApiScopeFactory>().CreateApiScope();
         }
 
         /// <summary>
         /// Gets the API configuration.
         /// </summary>
         public ApiConfiguration Configuration { get; private set; }
+
+        /// <summary>
+        /// Gets the <see cref="IServiceProvider"/> which contains all services of this <see cref="ApiContext"/>.
+        /// </summary>
+        public IServiceProvider ServiceProvider
+        {
+            get { return this.contextScope.ServiceProvider; }
+        }
+
+        /// <summary>
+        /// Gets a service instance.
+        /// </summary>
+        /// <typeparam name="T">The service type.</typeparam>
+        /// <returns>The service instance.</returns>
+        public T GetApiService<T>() where T : class
+        {
+            return this.ServiceProvider.GetService<T>();
+        }
+
+        internal void DisposeScope()
+        {
+            this.contextScope.Dispose();
+        }
     }
 }

--- a/src/Microsoft.Restier.Core/IApiScopeFactory.cs
+++ b/src/Microsoft.Restier.Core/IApiScopeFactory.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Framework.DependencyInjection;
+
+namespace Microsoft.Restier.Core
+{
+    /// <summary>
+    /// A factory to create <see cref="IServiceScope"/> for <see cref="ApiContext"/>.
+    /// </summary>
+    [CLSCompliant(false)]
+    public interface IApiScopeFactory
+    {
+        /// <summary>
+        /// Creates an <see cref="IServiceScope"/>.
+        /// </summary>
+        /// <returns>An <see cref="IServiceScope"/>.</returns>
+        IServiceScope CreateApiScope();
+    }
+}

--- a/src/Microsoft.Restier.Core/InvocationContext.cs
+++ b/src/Microsoft.Restier.Core/InvocationContext.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Restier.Core
         /// </remarks>
         public T GetHookHandler<T>() where T : class, IHookHandler
         {
-            return this.ApiContext.Configuration.GetHookHandler<T>();
+            return this.ApiContext.GetApiService<T>();
         }
     }
 }

--- a/src/Microsoft.Restier.Core/Microsoft.Restier.Core.csproj
+++ b/src/Microsoft.Restier.Core/Microsoft.Restier.Core.csproj
@@ -14,6 +14,14 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Framework.DependencyInjection, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Framework.DependencyInjection.1.0.0-beta8\lib\net45\Microsoft.Framework.DependencyInjection.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Framework.DependencyInjection.Abstractions, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Framework.DependencyInjection.Abstractions.1.0.0-beta8\lib\net45\Microsoft.Framework.DependencyInjection.Abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.OData.Edm, Version=6.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.OData.Edm.6.15.0-beta\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Edm.dll</HintPath>
       <Private>True</Private>
@@ -45,6 +53,7 @@
     <Compile Include="..\Shared\TypeExtensions.cs">
       <Link>Shared\TypeExtensions.cs</Link>
     </Compile>
+    <Compile Include="IApiScopeFactory.cs" />
     <Compile Include="Model\FunctionAttribute.cs" />
     <Compile Include="Model\ActionAttribute.cs" />
     <Compile Include="Conventions\ConventionBasedChangeSetAuthorizer.cs" />

--- a/src/Microsoft.Restier.Core/packages.config
+++ b/src/Microsoft.Restier.Core/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Framework.DependencyInjection" version="1.0.0-beta8" targetFramework="net45" />
+  <package id="Microsoft.Framework.DependencyInjection.Abstractions" version="1.0.0-beta8" targetFramework="net45" />
   <package id="Microsoft.OData.Edm" version="6.15.0-beta" targetFramework="net45" />
 </packages>

--- a/src/Microsoft.Restier.EntityFramework7/Microsoft.Restier.EntityFramework7.csproj
+++ b/src/Microsoft.Restier.EntityFramework7/Microsoft.Restier.EntityFramework7.csproj
@@ -73,8 +73,8 @@
       <HintPath>..\..\packages\Microsoft.Framework.OptionsModel.1.0.0-beta8\lib\net45\Microsoft.Framework.OptionsModel.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=6.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\Packages\Microsoft.OData.Edm.6.13.0\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Edm.dll</HintPath>
+    <Reference Include="Microsoft.OData.Edm, Version=6.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.OData.Edm.6.15.0-beta\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Edm.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Remotion.Linq, Version=2.0.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">

--- a/src/Microsoft.Restier.EntityFramework7/packages.config
+++ b/src/Microsoft.Restier.EntityFramework7/packages.config
@@ -13,7 +13,7 @@
   <package id="Microsoft.Framework.Logging" version="1.0.0-beta8" targetFramework="net451" />
   <package id="Microsoft.Framework.Logging.Abstractions" version="1.0.0-beta8" targetFramework="net451" />
   <package id="Microsoft.Framework.OptionsModel" version="1.0.0-beta8" targetFramework="net451" />
-  <package id="Microsoft.OData.Edm" version="6.13.0" targetFramework="net451" />
+  <package id="Microsoft.OData.Edm" version="6.15.0-beta" targetFramework="net451" />
   <package id="Remotion.Linq" version="2.0.0" targetFramework="net451" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net451" />
 </packages>

--- a/src/Microsoft.Restier.Samples.Northwind.EF7/Microsoft.Restier.Samples.Northwind.EF7.csproj
+++ b/src/Microsoft.Restier.Samples.Northwind.EF7/Microsoft.Restier.Samples.Northwind.EF7.csproj
@@ -98,16 +98,16 @@
       <HintPath>..\..\packages\Microsoft.Framework.Primitives.1.0.0-beta8\lib\net45\Microsoft.Framework.Primitives.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Core, Version=6.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\Packages\Microsoft.OData.Core.6.13.0\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Core.dll</HintPath>
+    <Reference Include="Microsoft.OData.Core, Version=6.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.OData.Core.6.15.0-beta\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=6.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\Packages\Microsoft.OData.Edm.6.13.0\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Edm.dll</HintPath>
+    <Reference Include="Microsoft.OData.Edm, Version=6.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.OData.Edm.6.15.0-beta\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Edm.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Spatial, Version=6.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\Packages\Microsoft.Spatial.6.13.0\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.Spatial.dll</HintPath>
+    <Reference Include="Microsoft.Spatial, Version=6.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Spatial.6.15.0-beta\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -139,8 +139,8 @@
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web" />
-    <Reference Include="System.Web.OData, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\Packages\Microsoft.AspNet.OData.5.7.0\lib\net45\System.Web.OData.dll</HintPath>
+    <Reference Include="System.Web.OData, Version=5.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.OData.5.9.0-Nightly160127\lib\net45\System.Web.OData.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />

--- a/src/Microsoft.Restier.Samples.Northwind.EF7/Web.config
+++ b/src/Microsoft.Restier.Samples.Northwind.EF7/Web.config
@@ -57,15 +57,15 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.OData.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.12.0.0" newVersion="6.12.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.13.0.0" newVersion="6.13.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.OData.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.12.0.0" newVersion="6.12.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.15.0.0" newVersion="6.15.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Spatial" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.12.0.0" newVersion="6.12.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.15.0.0" newVersion="6.15.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Remotion.Linq" publicKeyToken="fee00910d6e5f53b" culture="neutral" />

--- a/src/Microsoft.Restier.Samples.Northwind.EF7/packages.config
+++ b/src/Microsoft.Restier.Samples.Northwind.EF7/packages.config
@@ -4,7 +4,7 @@
   <package id="EntityFramework.Relational" version="7.0.0-beta8" targetFramework="net451" />
   <package id="EntityFramework.SqlServer" version="7.0.0-beta8" targetFramework="net451" />
   <package id="Ix-Async" version="1.2.5" targetFramework="net451" />
-  <package id="Microsoft.AspNet.OData" version="5.7.0" targetFramework="net45" />
+  <package id="Microsoft.AspNet.OData" version="5.9.0-Nightly160127" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.2" targetFramework="net45" />
@@ -20,9 +20,9 @@
   <package id="Microsoft.Framework.Logging.Abstractions" version="1.0.0-beta8" targetFramework="net451" />
   <package id="Microsoft.Framework.OptionsModel" version="1.0.0-beta8" targetFramework="net451" />
   <package id="Microsoft.Framework.Primitives" version="1.0.0-beta8" targetFramework="net451" />
-  <package id="Microsoft.OData.Core" version="6.13.0" targetFramework="net45" />
-  <package id="Microsoft.OData.Edm" version="6.13.0" targetFramework="net45" />
-  <package id="Microsoft.Spatial" version="6.13.0" targetFramework="net45" />
+  <package id="Microsoft.OData.Core" version="6.15.0-beta" targetFramework="net451" />
+  <package id="Microsoft.OData.Edm" version="6.15.0-beta" targetFramework="net451" />
+  <package id="Microsoft.Spatial" version="6.15.0-beta" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
   <package id="Remotion.Linq" version="2.0.0" targetFramework="net451" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net451" />

--- a/test/Microsoft.Restier.EntityFramework7.Tests/DateTests.cs
+++ b/test/Microsoft.Restier.EntityFramework7.Tests/DateTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Restier.EntityFramework.Tests
             {
                 dynamic newObj = new ExpandoObject();
                 newObj.DateProperty = "2016-01-04";
-                newObj.DTProperty = DateTime.Now;
+                newObj.DTProperty = DateTime.UtcNow;
                 newObj.DTOProperty = DateTimeOffset.Now;
                 newObj.TODProperty = "08:09:10";
                 newObj.TSProperty = "PT4H12M";
@@ -81,7 +81,7 @@ namespace Microsoft.Restier.EntityFramework.Tests
             {
                 dynamic newObj = new ExpandoObject();
                 newObj.DateProperty = "2016-01-04";
-                newObj.DTProperty = DateTime.Now;
+                newObj.DTProperty = DateTime.UtcNow;
                 newObj.DTOProperty = DateTimeOffset.Now;
                 newObj.RowId = 1024;
                 newObj.TODProperty = "08:09:10";
@@ -142,7 +142,7 @@ namespace Microsoft.Restier.EntityFramework.Tests
                 ctx.Add(new DateItem()
                 {
                     DateProperty = DateTime.Now,
-                    DTProperty = DateTime.Now,
+                    DTProperty = DateTime.UtcNow,
                     DTOProperty = DateTimeOffset.Now,
                     RowId = rowId,
                     TODProperty = TimeOfDay.Now,

--- a/test/Microsoft.Restier.EntityFramework7.Tests/Microsoft.Restier.EntityFramework7.Tests.csproj
+++ b/test/Microsoft.Restier.EntityFramework7.Tests/Microsoft.Restier.EntityFramework7.Tests.csproj
@@ -94,16 +94,16 @@
       <HintPath>..\..\packages\Microsoft.Framework.Primitives.1.0.0-beta8\lib\net45\Microsoft.Framework.Primitives.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Core, Version=6.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.OData.Core.6.13.0\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Core.dll</HintPath>
+    <Reference Include="Microsoft.OData.Core, Version=6.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.OData.Core.6.15.0-beta\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=6.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.OData.Edm.6.13.0\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Edm.dll</HintPath>
+    <Reference Include="Microsoft.OData.Edm, Version=6.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.OData.Edm.6.15.0-beta\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Edm.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Spatial, Version=6.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Spatial.6.13.0\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.Spatial.dll</HintPath>
+    <Reference Include="Microsoft.Spatial, Version=6.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Spatial.6.15.0-beta\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -138,8 +138,8 @@
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.2\lib\net45\System.Web.Http.WebHost.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Web.OData, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.OData.5.7.0\lib\net45\System.Web.OData.dll</HintPath>
+    <Reference Include="System.Web.OData, Version=5.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.OData.5.9.0-Nightly160127\lib\net45\System.Web.OData.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/test/Microsoft.Restier.EntityFramework7.Tests/app.config
+++ b/test/Microsoft.Restier.EntityFramework7.Tests/app.config
@@ -6,6 +6,18 @@
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.1.37.0" newVersion="1.1.37.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.OData.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.15.0.0" newVersion="6.15.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.OData.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.13.0.0" newVersion="6.13.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Spatial" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.15.0.0" newVersion="6.15.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/test/Microsoft.Restier.EntityFramework7.Tests/packages.config
+++ b/test/Microsoft.Restier.EntityFramework7.Tests/packages.config
@@ -5,7 +5,7 @@
   <package id="EntityFramework.Relational" version="7.0.0-beta8" targetFramework="net451" />
   <package id="EntityFramework.SqlServer" version="7.0.0-beta8" targetFramework="net451" />
   <package id="Ix-Async" version="1.2.5" targetFramework="net451" />
-  <package id="Microsoft.AspNet.OData" version="5.7.0" targetFramework="net451" />
+  <package id="Microsoft.AspNet.OData" version="5.9.0-Nightly160127" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi" version="5.2.2" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.2" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.2" targetFramework="net451" />
@@ -21,9 +21,9 @@
   <package id="Microsoft.Framework.Logging.Abstractions" version="1.0.0-beta8" targetFramework="net451" />
   <package id="Microsoft.Framework.OptionsModel" version="1.0.0-beta8" targetFramework="net451" />
   <package id="Microsoft.Framework.Primitives" version="1.0.0-beta8" targetFramework="net451" />
-  <package id="Microsoft.OData.Core" version="6.13.0" targetFramework="net451" />
-  <package id="Microsoft.OData.Edm" version="6.13.0" targetFramework="net451" />
-  <package id="Microsoft.Spatial" version="6.13.0" targetFramework="net451" />
+  <package id="Microsoft.OData.Core" version="6.15.0-beta" targetFramework="net451" />
+  <package id="Microsoft.OData.Edm" version="6.15.0-beta" targetFramework="net451" />
+  <package id="Microsoft.Spatial" version="6.15.0-beta" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net451" />
   <package id="Remotion.Linq" version="2.0.0" targetFramework="net451" />
   <package id="System.Collections" version="4.0.0" targetFramework="net451" />

--- a/test/Microsoft.Restier.Samples.Northwind.EF7.Tests/App.config
+++ b/test/Microsoft.Restier.Samples.Northwind.EF7.Tests/App.config
@@ -21,15 +21,15 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.OData.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.12.0.0" newVersion="6.12.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.13.0.0" newVersion="6.13.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.OData.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.12.0.0" newVersion="6.12.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.15.0.0" newVersion="6.15.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Spatial" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.12.0.0" newVersion="6.12.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.15.0.0" newVersion="6.15.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />

--- a/test/Microsoft.Restier.Samples.Northwind.EF7.Tests/Microsoft.Restier.Samples.Northwind.EF7.Tests.csproj
+++ b/test/Microsoft.Restier.Samples.Northwind.EF7.Tests/Microsoft.Restier.Samples.Northwind.EF7.Tests.csproj
@@ -93,16 +93,16 @@
       <HintPath>..\..\packages\Microsoft.Framework.Primitives.1.0.0-beta8\lib\net45\Microsoft.Framework.Primitives.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Core, Version=6.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\Packages\Microsoft.OData.Core.6.13.0\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Core.dll</HintPath>
+    <Reference Include="Microsoft.OData.Core, Version=6.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.OData.Core.6.15.0-beta\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=6.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\Packages\Microsoft.OData.Edm.6.13.0\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Edm.dll</HintPath>
+    <Reference Include="Microsoft.OData.Edm, Version=6.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.OData.Edm.6.15.0-beta\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Edm.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Spatial, Version=6.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\Packages\Microsoft.Spatial.6.13.0\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.Spatial.dll</HintPath>
+    <Reference Include="Microsoft.Spatial, Version=6.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Spatial.6.15.0-beta\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -137,8 +137,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.2\lib\net45\System.Web.Http.WebHost.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.OData, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\Packages\Microsoft.AspNet.OData.5.7.0\lib\net45\System.Web.OData.dll</HintPath>
+    <Reference Include="System.Web.OData, Version=5.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.OData.5.9.0-Nightly160127\lib\net45\System.Web.OData.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="xunit, Version=1.9.2.1705, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">

--- a/test/Microsoft.Restier.Samples.Northwind.EF7.Tests/packages.config
+++ b/test/Microsoft.Restier.Samples.Northwind.EF7.Tests/packages.config
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EntityFramework.Core" version="7.0.0-beta8" targetFramework="net451" />
   <package id="EntityFramework.Relational" version="7.0.0-beta8" targetFramework="net451" />
   <package id="EntityFramework.SqlServer" version="7.0.0-beta8" targetFramework="net451" />
   <package id="Ix-Async" version="1.2.5" targetFramework="net451" />
-  <package id="Microsoft.AspNet.OData" version="5.7.0" targetFramework="net451" />
+  <package id="Microsoft.AspNet.OData" version="5.9.0-Nightly160127" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.2" targetFramework="net45" />
@@ -19,11 +19,11 @@
   <package id="Microsoft.Framework.Logging.Abstractions" version="1.0.0-beta8" targetFramework="net451" />
   <package id="Microsoft.Framework.OptionsModel" version="1.0.0-beta8" targetFramework="net451" />
   <package id="Microsoft.Framework.Primitives" version="1.0.0-beta8" targetFramework="net451" />
-  <package id="Microsoft.OData.Core" version="6.13.0" targetFramework="net451" />
-  <package id="Microsoft.OData.Edm" version="6.13.0" targetFramework="net451" />
-  <package id="Microsoft.Spatial" version="6.13.0" targetFramework="net451" />
+  <package id="Microsoft.OData.Core" version="6.15.0-beta" targetFramework="net451" />
+  <package id="Microsoft.OData.Edm" version="6.15.0-beta" targetFramework="net451" />
+  <package id="Microsoft.Spatial" version="6.15.0-beta" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
   <package id="Remotion.Linq" version="2.0.0" targetFramework="net451" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net451" />
-  <package id="xunit" version="1.9.2" targetFramework="net451" />
+  <package id="xunit" version="2.0.0" targetFramework="net451" />
 </packages>

--- a/test/Microsoft.Restier.TestCommon/PublicApi.bsl
+++ b/test/Microsoft.Restier.TestCommon/PublicApi.bsl
@@ -2,6 +2,13 @@ public interface Microsoft.Restier.Core.IApi : IDisposable {
 	Microsoft.Restier.Core.ApiContext Context  { public abstract get; }
 }
 
+[
+CLSCompliantAttribute(),
+]
+public interface Microsoft.Restier.Core.IApiScopeFactory {
+	Microsoft.Framework.DependencyInjection.IServiceScope CreateApiScope ()
+}
+
 public interface Microsoft.Restier.Core.IDelegateHookHandler`1 {
 	T InnerHandler  { public abstract get; public abstract set; }
 }
@@ -111,6 +118,26 @@ public sealed class Microsoft.Restier.Core.ApiConfigurationExtensions {
 	ExtensionAttribute(),
 	]
 	public static Microsoft.Restier.Core.ApiConfiguration IgnoreProperty (Microsoft.Restier.Core.ApiConfiguration configuration, string propertyName)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.Restier.Core.ApiConfiguration TryUseContextApiScope (Microsoft.Restier.Core.ApiConfiguration obj)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.Restier.Core.ApiConfiguration TryUseSharedApiScope (Microsoft.Restier.Core.ApiConfiguration obj)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.Restier.Core.ApiConfiguration UseContextApiScope (Microsoft.Restier.Core.ApiConfiguration obj)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.Restier.Core.ApiConfiguration UseSharedApiScope (Microsoft.Restier.Core.ApiConfiguration obj)
 }
 
 public sealed class Microsoft.Restier.Core.ApiData {
@@ -125,18 +152,37 @@ public sealed class Microsoft.Restier.Core.ApiData {
 
 public class Microsoft.Restier.Core.ApiConfiguration : Microsoft.Restier.Core.PropertyBag {
 	public ApiConfiguration ()
+	[
+	CLSCompliantAttribute(),
+	]
+	public ApiConfiguration (Microsoft.Framework.DependencyInjection.IServiceCollection services)
 
 	bool IsCommitted  { [CompilerGeneratedAttribute(),]public get; }
+	System.IServiceProvider ServiceProvider  { public get; }
+	[
+	CLSCompliantAttribute(),
+	]
+	Microsoft.Framework.DependencyInjection.IServiceCollection Services  { public get; }
 
+	public Microsoft.Restier.Core.ApiConfiguration AddContributor (ApiServiceContributor`1 contributor)
 	public Microsoft.Restier.Core.ApiConfiguration AddHookHandler (T handler)
+	protected virtual System.IServiceProvider BuildServiceProvider ()
+	public Microsoft.Restier.Core.ApiConfiguration ChainPrevious (Func`2 factory)
+	public Microsoft.Restier.Core.ApiConfiguration ChainPrevious (Func`3 factory)
 	public void EnsureCommitted ()
 	public T GetHookHandler ()
+	public Microsoft.Restier.Core.ApiConfiguration MakeScoped ()
+	public Microsoft.Restier.Core.ApiConfiguration MakeSingleton ()
+	public Microsoft.Restier.Core.ApiConfiguration MakeTransient ()
 }
 
 public class Microsoft.Restier.Core.ApiContext : Microsoft.Restier.Core.PropertyBag {
 	public ApiContext (Microsoft.Restier.Core.ApiConfiguration configuration)
 
 	Microsoft.Restier.Core.ApiConfiguration Configuration  { [CompilerGeneratedAttribute(),]public get; }
+	System.IServiceProvider ServiceProvider  { public get; }
+
+	public T GetApiService ()
 }
 
 public class Microsoft.Restier.Core.InvocationContext : Microsoft.Restier.Core.PropertyBag {
@@ -155,6 +201,14 @@ public class Microsoft.Restier.Core.PropertyBag {
 	public T GetProperty (string name)
 	public virtual bool HasProperty (string name)
 	public void SetProperty (string name, object value)
+}
+
+public sealed class Microsoft.Restier.Core.ApiServiceContributor`1 : System.MulticastDelegate, ICloneable, ISerializable {
+	public ApiServiceContributor`1 (object object, System.IntPtr method)
+
+	public virtual System.IAsyncResult BeginInvoke (System.IServiceProvider serviceProvider, Func`1 next, System.AsyncCallback callback, object object)
+	public virtual T EndInvoke (System.IAsyncResult result)
+	public virtual T Invoke (System.IServiceProvider serviceProvider, Func`1 next)
 }
 
 public class Microsoft.Restier.EntityFramework.DbApi`1 : Microsoft.Restier.Core.ApiBase, IDisposable, IApi {


### PR DESCRIPTION
Use Micorsoft DI framework to replace current Dictionary<,> based service registration.
This is basically identical to my previous  #264. Compared to option 1 #285, this is a relatively conservative change. It's up to you to make a choice.
In this change ApiConfiguration has its service registration/resolve built upon MS.FX.DI, almost all public interfaces remain same.
There's 1 major breaking change:
Services or hook handlers can't be resolved before ApiConfiguraion committed.

Personally I like option 1 more, IMO it's cleaner, more componentized, and the building pattern mimics what's in ASP.NET MVC.