### PR TITLE
Issue 123 - Int64 Primary Keys

### DIFF
--- a/src/Microsoft.Restier.WebApi/RestierQueryBuilder.cs
+++ b/src/Microsoft.Restier.WebApi/RestierQueryBuilder.cs
@@ -147,8 +147,7 @@ namespace Microsoft.Restier.WebApi
             object propertyValue)
         {
             var property = Expression.Property(parameterExpression, propertyName);
-            var constant = Expression.Constant(propertyValue);
-
+            var constant = Expression.Constant(Convert.ChangeType(propertyValue, property.Type));
             return Expression.Equal(property, constant);
         }
         #endregion


### PR DESCRIPTION
Altered the expression construction in RestierQueryBuilder to use
Convert.ChangeType for key comparisons.