### PR TITLE
Fix TFS build break

### DIFF
--- a/src/Microsoft.Restier.Core/ApiBuilder.cs
+++ b/src/Microsoft.Restier.Core/ApiBuilder.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Linq;
-using Microsoft.Framework.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Restier.Core.Query;
 
 namespace Microsoft.Restier.Core

--- a/src/Microsoft.Restier.Core/ApiBuilderExtensions.cs
+++ b/src/Microsoft.Restier.Core/ApiBuilderExtensions.cs
@@ -6,8 +6,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Restier.Core.Properties;
 
 namespace Microsoft.Restier.Core

--- a/src/Microsoft.Restier.Core/ApiBuilderExtensions.cs
+++ b/src/Microsoft.Restier.Core/ApiBuilderExtensions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Restier.Core
         /// <returns>Current <see cref="ApiBuilder"/></returns>
         public static ApiBuilder UseSharedApiScope(this ApiBuilder obj)
         {
-            Ensure.NotNull(obj, nameof(obj));
+            Ensure.NotNull(obj, "obj");
 
             obj.Services.AddSingleton<IApiScopeFactory>(SharedApiScopeFactory.Creator);
             return obj;
@@ -39,7 +39,7 @@ namespace Microsoft.Restier.Core
         /// <returns>Current <see cref="ApiBuilder"/></returns>
         public static ApiBuilder UseContextApiScope(this ApiBuilder obj)
         {
-            Ensure.NotNull(obj, nameof(obj));
+            Ensure.NotNull(obj, "obj");
 
             obj.Services.AddSingleton<IApiScopeFactory>(ContextApiScopeFactory.Creator);
             return obj;
@@ -53,7 +53,7 @@ namespace Microsoft.Restier.Core
         /// <returns>Current <see cref="ApiBuilder"/></returns>
         public static ApiBuilder TryUseSharedApiScope(this ApiBuilder obj)
         {
-            Ensure.NotNull(obj, nameof(obj));
+            Ensure.NotNull(obj, "obj");
 
             obj.Services.TryAddSingleton(typeof(IApiScopeFactory), SharedApiScopeFactory.Creator);
             return obj;
@@ -67,7 +67,7 @@ namespace Microsoft.Restier.Core
         /// <returns>Current <see cref="ApiBuilder"/></returns>
         public static ApiBuilder TryUseContextApiScope(this ApiBuilder obj)
         {
-            Ensure.NotNull(obj, nameof(obj));
+            Ensure.NotNull(obj, "obj");
 
             obj.Services.TryAddSingleton(typeof(IApiScopeFactory), ContextApiScopeFactory.Creator);
             return obj;
@@ -83,7 +83,7 @@ namespace Microsoft.Restier.Core
         /// </returns>
         public static bool HasHookHandler<T>(this ApiBuilder obj) where T : class, IHookHandler
         {
-            Ensure.NotNull(obj, nameof(obj));
+            Ensure.NotNull(obj, "obj");
 
             return obj.Services.Any(sd => sd.ServiceType == typeof(LegacyHookHandler<T>));
         }
@@ -97,7 +97,7 @@ namespace Microsoft.Restier.Core
         /// <returns>Current <see cref="ApiBuilder"/></returns>
         public static ApiBuilder AddHookHandler<T>(this ApiBuilder obj, T handler) where T : class, IHookHandler
         {
-            Ensure.NotNull(obj, nameof(obj));
+            Ensure.NotNull(obj, "obj");
             Ensure.NotNull(handler, "handler");
 
             if (!typeof(T).IsInterface)
@@ -133,7 +133,7 @@ namespace Microsoft.Restier.Core
         /// <returns>Current <see cref="ApiBuilder"/></returns>
         public static ApiBuilder AddInstance<T>(this ApiBuilder obj, T instance) where T : class
         {
-            Ensure.NotNull(obj, nameof(obj));
+            Ensure.NotNull(obj, "obj");
 
             obj.Services.AddInstance<T>(instance);
             return obj;
@@ -149,8 +149,8 @@ namespace Microsoft.Restier.Core
         public static ApiBuilder AddContributor<T>(this ApiBuilder obj, ApiServiceContributor<T> contributor)
             where T : class
         {
-            Ensure.NotNull(obj, nameof(obj));
-            Ensure.NotNull(contributor, nameof(contributor));
+            Ensure.NotNull(obj, "obj");
+            Ensure.NotNull(contributor, "contributor");
 
             // Services have singleton lifetime by default, call Make... to change.
             obj.Services.TryAddSingleton(typeof(T), ChainedService<T>.DefaultFactory);
@@ -171,7 +171,7 @@ namespace Microsoft.Restier.Core
         public static ApiBuilder ChainPrevious<T>(this ApiBuilder obj, Func<IServiceProvider, T, T> factory)
             where T : class
         {
-            Ensure.NotNull(factory, nameof(factory));
+            Ensure.NotNull(factory, "factory");
             return obj.AddContributor<T>((sp, next) => factory(sp, next()));
         }
 
@@ -186,7 +186,7 @@ namespace Microsoft.Restier.Core
         /// <returns>Current <see cref="ApiBuilder"/></returns>
         public static ApiBuilder ChainPrevious<T>(this ApiBuilder obj, Func<T, T> factory) where T : class
         {
-            Ensure.NotNull(factory, nameof(factory));
+            Ensure.NotNull(factory, "factory");
             return obj.AddContributor<T>((sp, next) => factory(next()));
         }
 
@@ -239,7 +239,7 @@ namespace Microsoft.Restier.Core
         /// <returns>Current <see cref="ApiBuilder"/></returns>
         public static ApiBuilder MakeSingleton<T>(this ApiBuilder obj) where T : class
         {
-            Ensure.NotNull(obj, nameof(obj));
+            Ensure.NotNull(obj, "obj");
             obj.Services.AddSingleton<T>(ChainedService<T>.DefaultFactory);
             return obj;
         }
@@ -252,7 +252,7 @@ namespace Microsoft.Restier.Core
         /// <returns>Current <see cref="ApiBuilder"/></returns>
         public static ApiBuilder MakeScoped<T>(this ApiBuilder obj) where T : class
         {
-            Ensure.NotNull(obj, nameof(obj));
+            Ensure.NotNull(obj, "obj");
             obj.Services.AddScoped<T>(ChainedService<T>.DefaultFactory);
             return obj;
         }
@@ -265,7 +265,7 @@ namespace Microsoft.Restier.Core
         /// <returns>Current <see cref="ApiBuilder"/></returns>
         public static ApiBuilder MakeTransient<T>(this ApiBuilder obj) where T : class
         {
-            Ensure.NotNull(obj, nameof(obj));
+            Ensure.NotNull(obj, "obj");
             obj.Services.AddTransient<T>(ChainedService<T>.DefaultFactory);
             return obj;
         }
@@ -293,7 +293,7 @@ namespace Microsoft.Restier.Core
             this ApiBuilder obj,
             Func<ApiBuilder, IServiceProvider> serviceProviderFactory)
         {
-            Ensure.NotNull(obj, nameof(obj));
+            Ensure.NotNull(obj, "obj");
 
             obj.Services.TryAddSingleton<ApiConfiguration>();
             obj.TryUseContextApiScope();
@@ -320,7 +320,7 @@ namespace Microsoft.Restier.Core
         /// </example>
         public static T BuildApiServiceChain<T>(this IServiceProvider obj) where T : class
         {
-            Ensure.NotNull(obj, nameof(obj));
+            Ensure.NotNull(obj, "obj");
             return ChainedService<T>.DefaultFactory(obj);
         }
 

--- a/src/Microsoft.Restier.Core/ApiConfiguration.cs
+++ b/src/Microsoft.Restier.Core/ApiConfiguration.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.Framework.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OData.Edm;
 using Microsoft.Restier.Core.Properties;
 

--- a/src/Microsoft.Restier.Core/ApiContext.cs
+++ b/src/Microsoft.Restier.Core/ApiContext.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.Framework.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Restier.Core.Properties;
 
 namespace Microsoft.Restier.Core

--- a/src/Microsoft.Restier.Core/IApiScopeFactory.cs
+++ b/src/Microsoft.Restier.Core/IApiScopeFactory.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
 using System;
-using Microsoft.Framework.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Restier.Core
 {

--- a/src/Microsoft.Restier.Core/Microsoft.Restier.Core.csproj
+++ b/src/Microsoft.Restier.Core/Microsoft.Restier.Core.csproj
@@ -14,12 +14,12 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Framework.DependencyInjection, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Framework.DependencyInjection.1.0.0-beta8\lib\net45\Microsoft.Framework.DependencyInjection.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.1.0.0-rc1-final\lib\net451\Microsoft.Extensions.DependencyInjection.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Framework.DependencyInjection.Abstractions, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Framework.DependencyInjection.Abstractions.1.0.0-beta8\lib\net45\Microsoft.Framework.DependencyInjection.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0-rc1-final\lib\net451\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.OData.Edm, Version=6.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/Microsoft.Restier.Core/packages.config
+++ b/src/Microsoft.Restier.Core/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Framework.DependencyInjection" version="1.0.0-beta8" targetFramework="net45" />
-  <package id="Microsoft.Framework.DependencyInjection.Abstractions" version="1.0.0-beta8" targetFramework="net45" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0-rc1-final" targetFramework="net451" requireReinstallation="true" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0-rc1-final" targetFramework="net451" requireReinstallation="true" />
   <package id="Microsoft.OData.Edm" version="6.15.0-beta" targetFramework="net45" />
 </packages>

--- a/test/Microsoft.Restier.TestCommon/PublicApi.bsl
+++ b/test/Microsoft.Restier.TestCommon/PublicApi.bsl
@@ -6,7 +6,7 @@ public interface Microsoft.Restier.Core.IApi : IDisposable {
 CLSCompliantAttribute(),
 ]
 public interface Microsoft.Restier.Core.IApiScopeFactory {
-	Microsoft.Framework.DependencyInjection.IServiceScope CreateApiScope ()
+	Microsoft.Extensions.DependencyInjection.IServiceScope CreateApiScope ()
 }
 
 public interface Microsoft.Restier.Core.IDelegateHookHandler`1 {
@@ -265,12 +265,12 @@ public sealed class Microsoft.Restier.Core.ApiBuilder {
 	[
 	CLSCompliantAttribute(),
 	]
-	public ApiBuilder (Microsoft.Framework.DependencyInjection.IServiceCollection services)
+	public ApiBuilder (Microsoft.Extensions.DependencyInjection.IServiceCollection services)
 
 	[
 	CLSCompliantAttribute(),
 	]
-	Microsoft.Framework.DependencyInjection.IServiceCollection Services  { [CompilerGeneratedAttribute(),]public get; }
+	Microsoft.Extensions.DependencyInjection.IServiceCollection Services  { [CompilerGeneratedAttribute(),]public get; }
 }
 
 public sealed class Microsoft.Restier.Core.ApiServiceContributor`1 : System.MulticastDelegate, ICloneable, ISerializable {


### PR DESCRIPTION
1. The digital signature of DI 1.0.0-beta8 is expired since 2/1/2016 which will fail strong name validation.
2. The TFS build machine is still using VS2013 so we have to remove the C# 6.0 language features in order to compile.