### PR TITLE
DI backed ApiPermission

### DIFF
--- a/src/Microsoft.Restier.Security/ApiConfigurationExtensions.cs
+++ b/src/Microsoft.Restier.Security/ApiConfigurationExtensions.cs
@@ -17,9 +17,6 @@ namespace Microsoft.Restier.Security
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static class ApiConfigurationExtensions
     {
-        private const string Permissions =
-            "Microsoft.Restier.Security.Permissions";
-
         /// <summary>
         /// Enables principal-supplied role-based security for an API.
         /// </summary>
@@ -37,31 +34,6 @@ namespace Microsoft.Restier.Security
             Ensure.NotNull(builder, "configuration");
             builder.AddHookHandler<IQueryExpressionInspector>(RoleBasedAuthorization.Default);
             builder.AddHookHandler<IQueryExpressionExpander>(RoleBasedAuthorization.Default);
-        }
-
-        /// <summary>
-        /// Adds an API permission to an API configuration.
-        /// </summary>
-        /// <param name="configuration">
-        /// An API configuration.
-        /// </param>
-        /// <param name="permission">
-        /// An API permission.
-        /// </param>
-        public static void AddPermission(
-            this ApiConfiguration configuration,
-            ApiPermission permission)
-        {
-            Ensure.NotNull(configuration, "configuration");
-            Ensure.NotNull(permission, "permission");
-            var permissions = configuration.GetProperty<List<ApiPermission>>(Permissions);
-            if (permissions == null)
-            {
-                permissions = new List<ApiPermission>();
-                configuration.SetProperty(Permissions, permissions);
-            }
-
-            permissions.Add(permission);
         }
     }
 }

--- a/src/Microsoft.Restier.Security/DenyAttribute.cs
+++ b/src/Microsoft.Restier.Security/DenyAttribute.cs
@@ -53,17 +53,15 @@ namespace Microsoft.Restier.Security
         public string To { get; set; }
 
         /// <summary>
-        /// Configures an API configuration.
+        /// Configure an API.
         /// </summary>
-        /// <param name="configuration">
-        /// An API configuration.
+        /// <param name="builder">
+        /// An <see cref="ApiBuilder"/>.
         /// </param>
         /// <param name="type">
         /// The API type on which this attribute was placed.
         /// </param>
-        public override void Configure(
-            ApiConfiguration configuration,
-            Type type)
+        public override void ConfigureApi(ApiBuilder builder, Type type)
         {
             var permission = ApiPermission.CreateDeny(
                 this.PermissionType,
@@ -71,7 +69,7 @@ namespace Microsoft.Restier.Security
                 this.OnNamespace,
                 this.On,
                 this.OnChild);
-            configuration.AddPermission(permission);
+            builder.AddInstance(permission);
         }
     }
 }

--- a/src/Microsoft.Restier.Security/GrantAttribute.cs
+++ b/src/Microsoft.Restier.Security/GrantAttribute.cs
@@ -53,17 +53,15 @@ namespace Microsoft.Restier.Security
         public string To { get; set; }
 
         /// <summary>
-        /// Configures an API configuration.
+        /// Configure an API.
         /// </summary>
-        /// <param name="configuration">
-        /// An API configuration.
+        /// <param name="builder">
+        /// An <see cref="ApiBuilder"/>.
         /// </param>
         /// <param name="type">
         /// The API type on which this attribute was placed.
         /// </param>
-        public override void Configure(
-            ApiConfiguration configuration,
-            Type type)
+        public override void ConfigureApi(ApiBuilder builder, Type type)
         {
             var permission = ApiPermission.CreateGrant(
                 this.PermissionType,
@@ -71,7 +69,7 @@ namespace Microsoft.Restier.Security
                 this.OnNamespace,
                 this.On,
                 this.OnChild);
-            configuration.AddPermission(permission);
+            builder.AddInstance(permission);
         }
     }
 }

--- a/src/Microsoft.Restier.Security/RoleBasedAuthorization.cs
+++ b/src/Microsoft.Restier.Security/RoleBasedAuthorization.cs
@@ -22,8 +22,6 @@ namespace Microsoft.Restier.Security
     public class RoleBasedAuthorization : IQueryExpressionInspector,
         IQueryExpressionExpander, IDelegateHookHandler<IQueryExpressionExpander>
     {
-        private const string Permissions = "Microsoft.Restier.Security.Permissions";
-
         private const string AssertedRoles = "Microsoft.Restier.Security.AssertedRoles";
 
         static RoleBasedAuthorization()
@@ -145,8 +143,7 @@ namespace Microsoft.Restier.Security
 
             var assertedRoles = context.QueryContext
                 .GetProperty<List<string>>(AssertedRoles);
-            var permissions = context.QueryContext.ApiContext.Configuration
-                .GetProperty<IEnumerable<ApiPermission>>(Permissions);
+            var permissions = context.QueryContext.ApiContext.GetApiService<IEnumerable<ApiPermission>>();
             if (permissions == null)
             {
                 throw new SecurityException(


### PR DESCRIPTION
Treat ApiPermission as api services. IMHO the entire role based security system could be registered as several types of api service, but that needs some design discussion. This change is the easiest part.