### PR TITLE
Thread-safe GetModelAsync

### DIFF
--- a/src/GlobalSuppressions.cs
+++ b/src/GlobalSuppressions.cs
@@ -177,6 +177,8 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.Core.Conventions.ConventionBasedChangeSetEntryValidator")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.Core.Conventions.ConventionBasedApiModelBuilder+QueryExpressionExpander")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.Core.Conventions.ConventionBasedApiModelBuilder+QueryExpressionSourcer")]
+[assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.Core.Conventions.ConventionBasedApiModelBuilder+ModelBuilder")]
+[assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.Core.Conventions.ConventionBasedApiModelBuilder+ModelMapper")]
 #endregion
 
 #endregion

--- a/src/Microsoft.Restier.Core/Api.cs
+++ b/src/Microsoft.Restier.Core/Api.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Restier.Core
             var builder = context.GetApiService<IModelBuilder>();
             if (builder == null)
             {
-                return null;
+                throw new InvalidOperationException(Resources.ModelBuilderNotRegistered);
             }
 
             Task<IEdmModel> running;

--- a/src/Microsoft.Restier.Core/Properties/Resources.Designer.cs
+++ b/src/Microsoft.Restier.Core/Properties/Resources.Designer.cs
@@ -61,24 +61,6 @@ namespace Microsoft.Restier.Core.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The specified `ApiConfiguration` is committed thus cannot be modified..
-        /// </summary>
-        internal static string ApiConfigurationIsCommitted {
-            get {
-                return ResourceManager.GetString("ApiConfigurationIsCommitted", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The specified `ApiConfiguration` should already be committed..
-        /// </summary>
-        internal static string ApiConfigurationShouldBeCommitted {
-            get {
-                return ResourceManager.GetString("ApiConfigurationShouldBeCommitted", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Calling the methods in &apos;QueryableSource&apos; or &apos;QueryableSource&lt;T&gt;&apos; is not supported..
         /// </summary>
         internal static string CallQueryableSourceNotSupported {
@@ -228,6 +210,15 @@ namespace Microsoft.Restier.Core.Properties {
         internal static string InvalidChangeSetEntryType {
             get {
                 return ResourceManager.GetString("InvalidChangeSetEntryType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to IEdmModel cannot be generated since API service IModelBuilder is not registered..
+        /// </summary>
+        internal static string ModelBuilderNotRegistered {
+            get {
+                return ResourceManager.GetString("ModelBuilderNotRegistered", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Restier.Core/Properties/Resources.resx
+++ b/src/Microsoft.Restier.Core/Properties/Resources.resx
@@ -117,12 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ApiConfigurationIsCommitted" xml:space="preserve">
-    <value>The specified `ApiConfiguration` is committed thus cannot be modified.</value>
-  </data>
-  <data name="ApiConfigurationShouldBeCommitted" xml:space="preserve">
-    <value>The specified `ApiConfiguration` should already be committed.</value>
-  </data>
   <data name="CallQueryableSourceNotSupported" xml:space="preserve">
     <value>Calling the methods in 'QueryableSource' or 'QueryableSource&lt;T&gt;' is not supported.</value>
   </data>
@@ -215,5 +209,8 @@
   </data>
   <data name="ValidationFailsTheOperation" xml:space="preserve">
     <value>The operation cannot be performed because one or more objects are invalid.  Please inspect the ValidationException.ValidationResults property for more information.</value>
+  </data>
+  <data name="ModelBuilderNotRegistered" xml:space="preserve">
+    <value>IEdmModel cannot be generated since API service IModelBuilder is not registered.</value>
   </data>
 </root>

--- a/test/Microsoft.Restier.Core.Tests/Model/DefaultModelHandler.Tests.cs
+++ b/test/Microsoft.Restier.Core.Tests/Model/DefaultModelHandler.Tests.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Restier.Core.Tests.Model
 
                     var models = await Task.WhenAll(tasks);
                     Assert.Equal(1, service.CalledCount);
-                    Assert.True(models.All(e => e == models[42]));
+                    Assert.True(models.All(e => object.ReferenceEquals(e, models[42])));
                 }
             }
         }
@@ -202,7 +202,7 @@ namespace Microsoft.Restier.Core.Tests.Model
 
                 var models = await Task.WhenAll(tasks);
                 Assert.Equal(2, service.CalledCount);
-                Assert.True(models.All(e => e == models[42]));
+                Assert.True(models.All(e => object.ReferenceEquals(e, models[42])));
             }
         }
     }

--- a/test/Microsoft.Restier.Core.Tests/Model/DefaultModelHandler.Tests.cs
+++ b/test/Microsoft.Restier.Core.Tests/Model/DefaultModelHandler.Tests.cs
@@ -150,12 +150,15 @@ namespace Microsoft.Restier.Core.Tests.Model
 
             using (var wait = new ManualResetEventSlim(false))
             {
-                var tasks = PrepareThreads(50, configuration, wait);
-                wait.Set();
+                for (int i = 0; i < 2; i++)
+                {
+                    var tasks = PrepareThreads(50, configuration, wait);
+                    wait.Set();
 
-                var models = await Task.WhenAll(tasks);
-                Assert.Equal(1, service.CalledCount);
-                Assert.True(models.All(e => e == models[42]));
+                    var models = await Task.WhenAll(tasks);
+                    Assert.Equal(1, service.CalledCount);
+                    Assert.True(models.All(e => e == models[42]));
+                }
             }
         }
 
@@ -195,9 +198,7 @@ namespace Microsoft.Restier.Core.Tests.Model
                 });
                 Assert.Equal(1, service.CalledCount);
 
-                wait.Reset();
-                tasks = PrepareThreads(50, configuration, wait);
-                wait.Set();
+                tasks = PrepareThreads(150, configuration, wait);
 
                 var models = await Task.WhenAll(tasks);
                 Assert.Equal(2, service.CalledCount);


### PR DESCRIPTION
This ONLY synchronizes multiple simultaneous calls to model building pipeline, WebApiConfig still could return before a long running GetModelAsync completes.
Partially resolve #304 