### PR TITLE
Fixed SaveChanges for entities with long as key

### DIFF
--- a/src/Microsoft.Restier.Core/Submit/ChangeSetEntry.cs
+++ b/src/Microsoft.Restier.Core/Submit/ChangeSetEntry.cs
@@ -324,14 +324,15 @@ namespace Microsoft.Restier.Core.Submit
             Expression where,
             KeyValuePair<string, object> item)
         {
-            MemberExpression name = Expression.Property(param, item.Key);
+            MemberExpression property = Expression.Property(param, item.Key);
             object itemValue = item.Value;
 
             // TODO GitHubIssue#31 : Check if LinqParameterContainer is necessary
             // Expression value = itemValue != null
             //     ? LinqParameterContainer.Parameterize(itemValue.GetType(), itemValue)
             //     : Expression.Constant(value: null);
-            BinaryExpression equal = Expression.Equal(name, Expression.Constant(item.Value));
+            var constant = Expression.Constant(Convert.ChangeType(itemValue, property.Type), property.Type);
+            BinaryExpression equal = Expression.Equal(property, constant);
             return where == null ? equal : Expression.AndAlso(where, equal);
         }
     }


### PR DESCRIPTION
Fixed SaveChanges for entities with long as key.  Before this fix, when
trying to SaveChanges for entity with long/Int.64 as key, the following
exception was thrown: The binary operator Equal is not defined for the
types 'System.Int64' and 'System.Int32'.