### PR TITLE
Handle $count in WebApi, through an injected IQueryExecutor

### DIFF
--- a/src/GlobalSuppressions.cs
+++ b/src/GlobalSuppressions.cs
@@ -95,6 +95,8 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.Core.Conventions.ConventionBasedApiModelBuilder+ModelMapper.#.ctor(Microsoft.Restier.Core.Conventions.ConventionBasedApiModelBuilder)")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.Core.Conventions.ConventionBasedApiModelBuilder+ModelMapper.#InnerModelMapper")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.Core.Submit.DataModificationEntry.#ServerValues")]
+[assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.EntityFramework.Query.QueryExecutor.#Inner")]
+[assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.WebApi.Query.QueryTotalCount.#Inner")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "System.Linq.Expressions.ExpressionHelperMethods.#QueryableSelectGeneric")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "System.Linq.Expressions.ExpressionHelperMethods.#QueryableSelectManyGeneric")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "System.Linq.Expressions.ExpressionHelpers.#Select(System.Linq.IQueryable,System.Linq.Expressions.LambdaExpression)")]
@@ -176,6 +178,7 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.Core.Conventions.ConventionBasedApiModelBuilder+QueryExpressionSourcer")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.Core.Conventions.ConventionBasedApiModelBuilder+ModelBuilder")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.Core.Conventions.ConventionBasedApiModelBuilder+ModelMapper")]
+[assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.WebApi.Query.ODataCountOption")]
 #endregion
 
 #endregion

--- a/src/Microsoft.Restier.Core/Query/DefaultQueryExecutor.cs
+++ b/src/Microsoft.Restier.Core/Query/DefaultQueryExecutor.cs
@@ -36,11 +36,6 @@ namespace Microsoft.Restier.Core.Query
         {
             Ensure.NotNull(context, "context");
             var result = new QueryResult(query.ToList());
-            if (context.Request.IncludeTotalCount == true)
-            {
-                result.TotalCount = ExpressionHelpers.GetCountableQuery(query).Count();
-            }
-
             return Task.FromResult(result);
         }
 

--- a/src/Microsoft.Restier.Core/Query/DefaultQueryHandler.cs
+++ b/src/Microsoft.Restier.Core/Query/DefaultQueryHandler.cs
@@ -67,13 +67,6 @@ namespace Microsoft.Restier.Core.Query
             if (elementType != null)
             {
                 var query = visitor.BaseQuery.Provider.CreateQuery(expression);
-                if (query is EnumerableQuery)
-                {
-                    // Use the default query executor to handle query created
-                    // from IEnumerable<T> by calling query.ToList().
-                    executor = DefaultQueryExecutor.Instance;
-                }
-
                 var method = typeof(IQueryExecutor)
                     .GetMethod("ExecuteQueryAsync")
                     .MakeGenericMethod(elementType);

--- a/src/Microsoft.Restier.Core/Query/QueryRequest.cs
+++ b/src/Microsoft.Restier.Core/Query/QueryRequest.cs
@@ -19,11 +19,7 @@ namespace Microsoft.Restier.Core.Query
         /// <param name="query">
         /// A composed query that was derived from a queryable source.
         /// </param>
-        /// <param name="includeTotalCount">
-        /// Indicates if the total number of items should be retrieved
-        /// when the result has been filtered using paging operators.
-        /// </param>
-        public QueryRequest(IQueryable query, bool? includeTotalCount = null)
+        public QueryRequest(IQueryable query)
         {
             Ensure.NotNull(query, "query");
             if (!(query is QueryableSource))
@@ -33,24 +29,12 @@ namespace Microsoft.Restier.Core.Query
             }
 
             this.Expression = query.Expression;
-            this.IncludeTotalCount = includeTotalCount;
         }
 
         /// <summary>
         /// Gets or sets the composed query expression.
         /// </summary>
         public Expression Expression { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether the total
-        /// number of items should be retrieved when the
-        /// result has been filtered using paging operators.
-        /// </summary>
-        /// <remarks>
-        /// Setting this to <c>true</c> may have a performance impact as
-        /// the data provider may need to execute two independent queries.
-        /// </remarks>
-        public bool? IncludeTotalCount { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the number

--- a/src/Microsoft.Restier.Core/Query/QueryResult.cs
+++ b/src/Microsoft.Restier.Core/Query/QueryResult.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Restier.Core.Query
         private Exception error;
         private IEdmEntitySet resultsSource;
         private IEnumerable results;
-        private long? totalCount;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="QueryResult" /> class with an error.
@@ -36,18 +35,10 @@ namespace Microsoft.Restier.Core.Query
         /// <param name="results">
         /// In-memory results.
         /// </param>
-        /// <param name="totalCount">
-        /// The total number of items represented by the
-        /// results had paging operators not been applied.
-        /// </param>
-        public QueryResult(IEnumerable results, long? totalCount = null)
+        public QueryResult(IEnumerable results)
         {
             Ensure.NotNull(results, "results");
             this.Results = results;
-            if (totalCount != null)
-            {
-                this.TotalCount = totalCount;
-            }
         }
 
         /// <summary>
@@ -69,7 +60,6 @@ namespace Microsoft.Restier.Core.Query
                 this.error = value;
                 this.resultsSource = null;
                 this.results = null;
-                this.totalCount = null;
             }
         }
 
@@ -118,35 +108,6 @@ namespace Microsoft.Restier.Core.Query
                 this.error = null;
                 this.resultsSource = null;
                 this.results = value;
-                this.totalCount = null;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the total number of items available but not
-        /// returned by a query whose items were filtered for paging.
-        /// </summary>
-        /// <remarks>
-        /// This should be <c>null</c> if total count
-        /// is not supported or was not requested.
-        /// </remarks>
-        public long? TotalCount
-        {
-            get
-            {
-                return this.totalCount;
-            }
-
-            set
-            {
-                if (this.results == null)
-                {
-                    throw new InvalidOperationException(
-                        Resources.CannotSetTotalCountIfThereIsNoResult);
-                }
-
-                Ensure.NotNull(value, "value");
-                this.totalCount = value;
             }
         }
     }

--- a/src/Microsoft.Restier.EntityFramework/DbApi.cs
+++ b/src/Microsoft.Restier.EntityFramework/DbApi.cs
@@ -60,14 +60,13 @@ namespace Microsoft.Restier.EntityFramework
         [CLSCompliant(false)]
         protected override IServiceCollection ConfigureApi(IServiceCollection services)
         {
-            services = base.ConfigureApi(services)
+            return base.ConfigureApi(services)
                 .CutoffPrevious<IModelBuilder>(ModelProducer.Instance)
                 .CutoffPrevious<IModelMapper>(new ModelMapper(typeof(T)))
                 .CutoffPrevious<IQueryExpressionSourcer, QueryExpressionSourcer>()
-                .CutoffPrevious<IQueryExecutor>(QueryExecutor.Instance)
+                .ChainPrevious<IQueryExecutor, QueryExecutor>()
                 .CutoffPrevious<IChangeSetPreparer, ChangeSetPreparer>()
-                .CutoffPrevious<ISubmitExecutor>(SubmitExecutor.Instance);
-            services
+                .CutoffPrevious<ISubmitExecutor>(SubmitExecutor.Instance)
                 .AddScoped<T>(sp =>
                 {
                     var dbContext = this.CreateDbContext(sp);
@@ -79,7 +78,6 @@ namespace Microsoft.Restier.EntityFramework
                     return dbContext;
                 })
                 .AddScoped<DbContext>(sp => sp.GetService<T>());
-            return services;
         }
 
         /// <summary>

--- a/src/Microsoft.Restier.EntityFramework7/Submit/ChangeSetPreparer.cs
+++ b/src/Microsoft.Restier.EntityFramework7/Submit/ChangeSetPreparer.cs
@@ -105,11 +105,10 @@ namespace Microsoft.Restier.EntityFramework.Submit
             DataModificationEntry entry,
             CancellationToken cancellationToken)
         {
-            IQueryable query = Api.Source(context.ApiContext, entry.EntitySetName);
+            IQueryable query = context.ApiContext.Source(entry.EntitySetName);
             query = entry.ApplyTo(query);
 
-            QueryResult result = await Api.QueryAsync(
-                context.ApiContext,
+            QueryResult result = await context.ApiContext.QueryAsync(
                 new QueryRequest(query),
                 cancellationToken);
 

--- a/src/Microsoft.Restier.WebApi/HttpConfigurationExtensions.cs
+++ b/src/Microsoft.Restier.WebApi/HttpConfigurationExtensions.cs
@@ -9,10 +9,13 @@ using System.Web.Http;
 using System.Web.OData.Extensions;
 using System.Web.OData.Routing;
 using System.Web.OData.Routing.Conventions;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OData.Core;
 using Microsoft.OData.Edm;
 using Microsoft.Restier.Core;
+using Microsoft.Restier.Core.Query;
 using Microsoft.Restier.WebApi.Batch;
+using Microsoft.Restier.WebApi.Query;
 using Microsoft.Restier.WebApi.Routing;
 
 namespace Microsoft.Restier.WebApi
@@ -44,6 +47,11 @@ namespace Microsoft.Restier.WebApi
         {
             Ensure.NotNull(apiFactory, "apiFactory");
 
+            ApiConfiguration.Configure<TApi>(services =>
+            {
+                services.AddScoped<ODataCountOption>()
+                    .ChainPrevious<IQueryExecutor, QueryTotalCount>();
+            });
             using (var api = apiFactory())
             {
                 var model = api.GetModelAsync().Result;

--- a/src/Microsoft.Restier.WebApi/Microsoft.Restier.WebApi.csproj
+++ b/src/Microsoft.Restier.WebApi/Microsoft.Restier.WebApi.csproj
@@ -13,6 +13,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0-rc1-final\lib\net451\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.OData.Core, Version=6.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.OData.Core.6.15.0-beta\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Core.dll</HintPath>
       <Private>True</Private>
@@ -87,6 +90,7 @@
     <Compile Include="Formatter\Serialization\RestierFeedSerializer.cs" />
     <Compile Include="HttpConfigurationExtensions.cs" />
     <Compile Include="HttpRequestMessageExtensions.cs" />
+    <Compile Include="Query\QueryTotalCount.cs" />
     <Compile Include="RestierQueryBuilder.cs" />
     <Compile Include="Extensions.cs" />
     <Compile Include="RestierFormattingAttribute.cs" />
@@ -116,6 +120,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>SharedResources.resx</DependentUpon>
     </Compile>
+    <Compile Include="Query\ODataCountOption.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Restier.Core\Microsoft.Restier.Core.csproj">

--- a/src/Microsoft.Restier.WebApi/Query/ODataCountOption.cs
+++ b/src/Microsoft.Restier.WebApi/Query/ODataCountOption.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Restier.WebApi.Query
+{
+    internal class ODataCountOption
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether the total
+        /// number of items should be retrieved when the
+        /// result has been filtered using paging operators.
+        /// </summary>
+        /// <remarks>
+        /// Setting this to <c>true</c> may have a performance impact as
+        /// the data provider may need to execute two independent queries.
+        /// </remarks>
+        public bool IncludeTotalCount { get; set; }
+
+        public Action<long> SetTotalCount { get; set; }
+    }
+}

--- a/src/Microsoft.Restier.WebApi/Query/QueryTotalCount.cs
+++ b/src/Microsoft.Restier.WebApi/Query/QueryTotalCount.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Restier.Core.Query;
+
+namespace Microsoft.Restier.WebApi.Query
+{
+    internal class QueryTotalCount : IQueryExecutor
+    {
+        public IQueryExecutor Inner { get; set; }
+
+        public async Task<QueryResult> ExecuteQueryAsync<TElement>(
+            QueryContext context,
+            IQueryable<TElement> query,
+            CancellationToken cancellationToken)
+        {
+            var countOption = context.ApiContext.GetApiService<ODataCountOption>();
+            if (countOption.IncludeTotalCount)
+            {
+                var countQuery = ExpressionHelpers.GetCountableQuery(query);
+                var expression = ExpressionHelpers.Count(countQuery.Expression, countQuery.ElementType);
+                var result = await ExecuteSingleAsync<long>(context, countQuery, expression, cancellationToken);
+                var totalCount = result.Results.Cast<long>().Single();
+
+                countOption.SetTotalCount(totalCount);
+            }
+
+            return await Inner.ExecuteQueryAsync<TElement>(context, query, cancellationToken);
+        }
+
+        public Task<QueryResult> ExecuteSingleAsync<TResult>(
+            QueryContext context,
+            IQueryable query,
+            Expression expression,
+            CancellationToken cancellationToken)
+        {
+            return Inner.ExecuteSingleAsync<TResult>(context, query, expression, cancellationToken);
+        }
+    }
+}

--- a/src/Microsoft.Restier.WebApi/RestierController.cs
+++ b/src/Microsoft.Restier.WebApi/RestierController.cs
@@ -25,6 +25,7 @@ using Microsoft.Restier.Core.Submit;
 using Microsoft.Restier.WebApi.Batch;
 using Microsoft.Restier.WebApi.Filters;
 using Microsoft.Restier.WebApi.Properties;
+using Microsoft.Restier.WebApi.Query;
 using Microsoft.Restier.WebApi.Results;
 
 namespace Microsoft.Restier.WebApi
@@ -40,7 +41,6 @@ namespace Microsoft.Restier.WebApi
         private const string ETagHeaderKey = "@etag";
 
         private ApiBase api;
-        private bool? includeTotalCount;
         private bool shouldReturnCount;
         private bool shouldWriteRawValue;
 
@@ -76,15 +76,11 @@ namespace Microsoft.Restier.WebApi
             }
 
             IQueryable queryable = this.GetQuery();
-            QueryRequest queryRequest = new QueryRequest(queryable, this.includeTotalCount)
+            QueryRequest queryRequest = new QueryRequest(queryable)
             {
                 ShouldReturnCount = this.shouldReturnCount
             };
             QueryResult queryResult = await Api.QueryAsync(queryRequest, cancellationToken);
-            if (this.includeTotalCount == true)
-            {
-                this.Request.ODataProperties().TotalCount = queryResult.TotalCount;
-            }
 
             this.Request.Properties[ETagGetterKey] = this.Api.Context.GetProperty(ETagGetterKey);
 
@@ -404,19 +400,16 @@ namespace Microsoft.Restier.WebApi
                         Resources.ResourceNotFound));
             }
 
-            if (this.shouldReturnCount || this.shouldWriteRawValue)
+            if (this.shouldWriteRawValue)
             {
-                // Query options don't apply to $count or $value.
+                // Query options don't apply to $value.
                 return queryable;
             }
 
+            HttpRequestMessageProperties properties = this.Request.ODataProperties();
             ODataQueryContext queryContext =
-                new ODataQueryContext(this.Request.ODataProperties().Model, queryable.ElementType, path);
+                new ODataQueryContext(properties.Model, queryable.ElementType, path);
             ODataQueryOptions queryOptions = new ODataQueryOptions(queryContext, this.Request);
-            if (queryOptions.Count != null)
-            {
-                this.includeTotalCount = queryOptions.Count.Value;
-            }
 
             // TODO GitHubIssue#41 : Ensure stable ordering for query
             ODataQuerySettings settings = new ODataQuerySettings
@@ -424,6 +417,21 @@ namespace Microsoft.Restier.WebApi
                 HandleNullPropagation = HandleNullPropagationOption.False,
                 PageSize = null,  // no support for server enforced PageSize, yet
             };
+
+            if (this.shouldReturnCount)
+            {
+                // Query options other than $filter and $search don't apply to $count.
+                queryable = queryOptions.ApplyTo(
+                    queryable, settings, AllowedQueryOptions.All ^ AllowedQueryOptions.Filter);
+                return queryable;
+            }
+
+            if (queryOptions.Count != null)
+            {
+                ODataCountOption context = Api.Context.GetApiService<ODataCountOption>();
+                context.IncludeTotalCount = queryOptions.Count.Value;
+                context.SetTotalCount = value => properties.TotalCount = value;
+            }
 
             // Entity count can NOT be evaluated at this point of time because the source
             // expression is just a placeholder to be replaced by the expression sourcer.

--- a/src/Microsoft.Restier.WebApi/packages.config
+++ b/src/Microsoft.Restier.WebApi/packages.config
@@ -3,6 +3,7 @@
   <package id="Microsoft.AspNet.OData" version="5.9.0-beta" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.2" targetFramework="net45" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0-rc1-final" targetFramework="net451" requireReinstallation="true" />
   <package id="Microsoft.OData.Core" version="6.15.0-beta" targetFramework="net45" />
   <package id="Microsoft.OData.Edm" version="6.15.0-beta" targetFramework="net45" />
   <package id="Microsoft.Spatial" version="6.15.0-beta" targetFramework="net45" />

--- a/test/Microsoft.Restier.Core.Tests/Api.Tests.cs
+++ b/test/Microsoft.Restier.Core.Tests/Api.Tests.cs
@@ -414,7 +414,7 @@ namespace Microsoft.Restier.Core.Tests
             var api = new TestApi();
 
             var queryRequest = new QueryRequest(
-                api.Source<string>("Test"), true);
+                api.Source<string>("Test"));
             var queryResult = await api.QueryAsync(queryRequest);
             Assert.True(queryResult.Results.Cast<string>()
                 .SequenceEqual(new string[] { "Test" }));

--- a/test/Microsoft.Restier.EntityFramework7.Tests/Models/Primitives/PrimitivesApi.cs
+++ b/test/Microsoft.Restier.EntityFramework7.Tests/Models/Primitives/PrimitivesApi.cs
@@ -13,11 +13,6 @@ namespace Microsoft.Restier.EntityFramework.Tests.Models.Primitives
 {
     class PrimitivesApi : DbApi<PrimitivesContext>
     {
-        internal ApiContext Context
-        {
-            get { return this.ApiContext; }
-        }
-
         internal PrimitivesContext DataContext
         {
             get { return (PrimitivesContext)this.DbContext; }

--- a/test/Microsoft.Restier.Samples.Northwind.Tests/OperationTests.cs
+++ b/test/Microsoft.Restier.Samples.Northwind.Tests/OperationTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Restier.Samples.Northwind.Tests
         {
             var query = this.api.Source<Product>("Products").OrderBy(p => p.ProductID).Take(1);
             QueryResult result = await this.api.QueryAsync(
-                   new QueryRequest(query, true));
+                   new QueryRequest(query));
 
             var product = result.Results.OfType<Product>().First();
             var price = product.UnitPrice;

--- a/test/Microsoft.Restier.Samples.Northwind.Tests/QueryTests.cs
+++ b/test/Microsoft.Restier.Samples.Northwind.Tests/QueryTests.cs
@@ -23,9 +23,8 @@ namespace Microsoft.Restier.Samples.Northwind.Tests
         public async Task TestTakeIncludeTotalCount()
         {
             QueryResult result = await this.api.QueryAsync(
-                new QueryRequest(this.OrdersQuery.OrderBy(o => o.OrderDate).Take(10), true));
+                new QueryRequest(this.OrdersQuery.OrderBy(o => o.OrderDate).Take(10)));
 
-            Assert.Equal(830, result.TotalCount);
             var orderResults = result.Results.OfType<Order>();
             Assert.Equal(10, orderResults.Count());
         }
@@ -34,9 +33,8 @@ namespace Microsoft.Restier.Samples.Northwind.Tests
         public async Task TestSkipIncludeTotalCount()
         {
             QueryResult result = await this.api.QueryAsync(
-                new QueryRequest(this.OrdersQuery.OrderBy(o => o.OrderDate).Skip(10), true));
+                new QueryRequest(this.OrdersQuery.OrderBy(o => o.OrderDate).Skip(10)));
 
-            Assert.Equal(830, result.TotalCount);
             var orderResults = result.Results.OfType<Order>();
             Assert.Equal(820, orderResults.Count());
         }
@@ -45,9 +43,8 @@ namespace Microsoft.Restier.Samples.Northwind.Tests
         public async Task TestSkipTakeIncludeTotalCount()
         {
             QueryResult result = await this.api.QueryAsync(
-                new QueryRequest(this.OrdersQuery.OrderBy(o => o.OrderDate).Skip(10).Take(25), true));
+                new QueryRequest(this.OrdersQuery.OrderBy(o => o.OrderDate).Skip(10).Take(25)));
 
-            Assert.Equal(830, result.TotalCount);
             var orderResults = result.Results.OfType<Order>();
             Assert.Equal(25, orderResults.Count());
         }
@@ -60,9 +57,8 @@ namespace Microsoft.Restier.Samples.Northwind.Tests
         public async Task TestTakeNotStrippedIncludeTotalCount()
         {
             QueryResult result = await this.api.QueryAsync(
-                new QueryRequest(this.OrdersQuery.Take(10).OrderBy(o => o.OrderDate), true));
+                new QueryRequest(this.OrdersQuery.Take(10).OrderBy(o => o.OrderDate)));
 
-            Assert.Equal(10, result.TotalCount);
             var orderResults = result.Results.OfType<Order>();
             Assert.Equal(10, orderResults.Count());
         }

--- a/test/Microsoft.Restier.TestCommon/PublicApi.bsl
+++ b/test/Microsoft.Restier.TestCommon/PublicApi.bsl
@@ -469,21 +469,19 @@ public class Microsoft.Restier.Core.Query.QueryExpressionContext {
 }
 
 public class Microsoft.Restier.Core.Query.QueryRequest {
-	public QueryRequest (System.Linq.IQueryable query, params System.Nullable`1[[System.Boolean]] includeTotalCount)
+	public QueryRequest (System.Linq.IQueryable query)
 
 	System.Linq.Expressions.Expression Expression  { [CompilerGeneratedAttribute(),]public get; [CompilerGeneratedAttribute(),]public set; }
-	System.Nullable`1[[System.Boolean]] IncludeTotalCount  { [CompilerGeneratedAttribute(),]public get; [CompilerGeneratedAttribute(),]public set; }
 	bool ShouldReturnCount  { [CompilerGeneratedAttribute(),]public get; [CompilerGeneratedAttribute(),]public set; }
 }
 
 public class Microsoft.Restier.Core.Query.QueryResult {
+	public QueryResult (System.Collections.IEnumerable results)
 	public QueryResult (System.Exception error)
-	public QueryResult (System.Collections.IEnumerable results, params System.Nullable`1[[System.Int64]] totalCount)
 
 	System.Exception Error  { public get; public set; }
 	System.Collections.IEnumerable Results  { public get; public set; }
 	Microsoft.OData.Edm.IEdmEntitySet ResultsSource  { public get; public set; }
-	System.Nullable`1[[System.Int64]] TotalCount  { public get; public set; }
 }
 
 public enum Microsoft.Restier.Core.Submit.AddAction : int {

--- a/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Scenario/TrippinE2ETestCases.cs
+++ b/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Scenario/TrippinE2ETestCases.cs
@@ -882,6 +882,9 @@ namespace Microsoft.Restier.WebApi.Test.Scenario
         [InlineData("People/$count", "13")]
         [InlineData("People(1)/Friends/$count", "1")]
         [InlineData("Flights/$count", "4")]
+        [InlineData("People/$count?$filter=indexof(FirstName,'R') eq 0", "3")]
+        [InlineData("People/$count?$filter=indexof(FirstName,'R') eq 0&$top(1)", "3")]
+        [InlineData("People/$count?$filter=indexof(FirstName,'R') eq 0&$skip(1)&$top(1)", "3")]
         public void TestCountEntities(string uriStringAfterServiceRoot, string expectedString)
         {
             this.TestGetPayloadIs(uriStringAfterServiceRoot, expectedString);


### PR DESCRIPTION
WebApi publisher implements an IQueryExecutor to run an additional total count query.