### PR TITLE
Add test case for null case and fix issues found

### DIFF
--- a/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Scenario/E2ETestBase.cs
+++ b/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Scenario/E2ETestBase.cs
@@ -69,11 +69,21 @@ namespace Microsoft.Restier.WebApi.Test.Scenario
             var requestMessage = new HttpWebRequestMessage(
                 new DataServiceClientRequestMessageArgs(
                     "GET",
-                    new Uri(this.ServiceBaseUri, uriStringAfterServiceRoot),
+                    new Uri(this.ServiceBaseUri + uriStringAfterServiceRoot, UriKind.Absolute),
                     useDefaultCredentials: true,
                     usePostTunneling: false,
                     headers: new Dictionary<string, string>()));
-            Assert.Equal(statusCode, requestMessage.GetResponse().StatusCode);
+
+            try
+            {
+                Assert.Equal(statusCode, requestMessage.GetResponse().StatusCode);
+            }
+            catch (DataServiceTransportException e)
+            {
+                // In case of 404 or 500, it will be handled here
+                var response = e.Response;
+                Assert.Equal(statusCode, response.StatusCode);
+            }
         }
 
         protected void TestPostPayloadContains(string uriStringAfterServiceRoot, string expectedSubString)

--- a/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Scenario/Microsoft.Restier.WebApi.Test.Scenario.csproj
+++ b/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Scenario/Microsoft.Restier.WebApi.Test.Scenario.csproj
@@ -36,6 +36,7 @@
     <Compile Include="PropertyAccessTests.cs" />
     <Compile Include="TrippinE2ETestBase.cs" />
     <Compile Include="TemporalTests.cs" />
+    <Compile Include="TrippinE2ETestCases.cs" />
     <Compile Include="TrippinInMemoryE2ETest.cs" />
     <Compile Include="TrippinServiceFixture.cs" />
     <Compile Include="E2ETestBase.cs" />
@@ -44,7 +45,6 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>TrippinProxy.tt</DependentUpon>
     </Compile>
-    <Compile Include="TrippinE2ETestCases.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="UrlConventionsTests.cs" />
   </ItemGroup>
@@ -62,19 +62,19 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.OData.Client, Version=6.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.OData.Client.6.15.0-beta\lib\net40\Microsoft.OData.Client.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.OData.Client.6.15.0\lib\net40\Microsoft.OData.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.OData.Core, Version=6.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.OData.Core.6.15.0-beta\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Core.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.OData.Core.6.15.0\lib\portable-net45+win+wpa81\Microsoft.OData.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.OData.Edm, Version=6.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.OData.Edm.6.15.0-beta\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Edm.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.OData.Edm.6.15.0\lib\portable-net45+win+wpa81\Microsoft.OData.Edm.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Spatial, Version=6.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.Spatial.6.15.0-beta\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.Spatial.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Spatial.6.15.0\lib\portable-net45+win+wpa81\Microsoft.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Scenario/PropertyAccessTests.cs
+++ b/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Scenario/PropertyAccessTests.cs
@@ -211,12 +211,7 @@ namespace Microsoft.Restier.WebApi.Test.Scenario
         [Fact]
         public void QueryNullEnumPropertyOfSingleEntity()
         {
-            TestPayloadString("People(1)/FavoriteFeature2", payloadStr =>
-            {
-                Assert.Contains(
-                    "\"@odata.context\":\"http://localhost:18384/api/Trippin/$metadata#People(1)/FavoriteFeature2\"," +
-                    "\"@odata.null\":true", payloadStr, StringComparison.Ordinal);
-            });
+            TestGetStatusCodeIs("People(1)/FavoriteFeature2", 204);
         }
 
         [Fact]
@@ -240,10 +235,30 @@ namespace Microsoft.Restier.WebApi.Test.Scenario
         [Fact]
         public void QueryNullRawEnumPropertyOfSingleEntity()
         {
-            TestPayloadString("People(1)/FavoriteFeature2/$value", payloadStr =>
-            {
-                Assert.Equal(string.Empty, payloadStr, StringComparer.Ordinal);
-            });
+            TestGetStatusCodeIs("People(1)/FavoriteFeature2/$value", 204);
+        }
+
+        /// Note: 1.null collection of any type (primitive/enum/Complex/navCollection) is not tested yet.
+        /// 2. No test case of collection with primitive/enum/complex as EF does not support
+        /// 3. Complex can not be null in EF
+        [Theory]
+        // Single primitive property with null value 
+        [InlineData("/People(4)/LastName", 204)]
+        // Single primitive property $value with null value 
+        [InlineData("/People(4)/LastName/$value", 204)]
+        // single navigation property with null value
+        // TODO Should be 204, cannot differentiate ~/People(nonexistkey) vs /People(5)/NullSingNav now
+        [InlineData("/People(4)/BestFriend", 404)]
+        // single navigation property's propery and navigation property has null value
+        // TODO should be 404
+        [InlineData("/People(4)/BestFriend/LastName", 204)]
+        // single navigation property's property with null value
+        [InlineData("/People(5)/BestFriend/LastName", 204)]
+        // collection of navigation property with empty collection value
+        [InlineData("/People(5)/Friends", 200)]
+        public void QueryPropertyWithNullValueStatusCode(string url, int expectedCode)
+        {
+            TestGetStatusCodeIs(url, expectedCode);
         }
 
         private void TestPayloadString(string uriAfterServiceRoot, Action<string> testMethod)

--- a/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Scenario/TrippinE2ETestCases.cs
+++ b/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Scenario/TrippinE2ETestCases.cs
@@ -897,12 +897,18 @@ namespace Microsoft.Restier.WebApi.Test.Scenario
         [Theory]
         [InlineData("Me/UserName", "http://localhost:18384/api/Trippin/$metadata#Me/UserName")]
         [InlineData("Me/FavoriteFeature", "http://localhost:18384/api/Trippin/$metadata#Me/FavoriteFeature")]
-        [InlineData("Me/FavoriteFeature2", "http://localhost:18384/api/Trippin/$metadata#Me/FavoriteFeature2")]
         [InlineData("Me/Friends", "http://localhost:18384/api/Trippin/$metadata#People")]
         [InlineData("Me/Trips", "http://localhost:18384/api/Trippin/$metadata#Trips")]
         public void TestSingletonPropertyAccess(string uriStringAfterServiceRoot, string expectedSubString)
         {
             this.TestGetPayloadContains(uriStringAfterServiceRoot, expectedSubString);
+        }
+
+        [Theory]
+        [InlineData("Me/FavoriteFeature2", 204)]
+        public void TestSingletonPropertyAccessStatus(string uriStringAfterServiceRoot, int statusCode)
+        {
+            this.TestGetStatusCodeIs(uriStringAfterServiceRoot, statusCode);
         }
 
         [Theory]

--- a/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Scenario/TrippinInMemoryE2ETest.cs
+++ b/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Scenario/TrippinInMemoryE2ETest.cs
@@ -82,5 +82,87 @@ namespace Microsoft.Restier.WebApi.Test.Scenario
         {
             TestGetPayloadContains("People", "\"Friends\":[");
         }
+
+        [Theory]
+        // Note, null collection of any type (primitive/enum/Complex/navCollection) is not tested.
+        // Single primitive property with null value 
+        [InlineData("/People(5)/MiddleName", 204)]
+        // Single primitive property $value with null value 
+        [InlineData("/People(5)/MiddleName/$value", 204)]
+        // Collection of primitive property with empty value 
+        [InlineData("/People(5)/Emails", 200)]
+        // Collection of primitive property $value with null value, should throw exception
+        // TODO should be bad request 400 as this is not allowed, 404 is returned by WebApi Route Match method
+        [InlineData("/People(5)/Emails/$value", 404)]
+        // single complex property with null value
+        [InlineData("/People(5)/HomeAddress", 204)]
+        // single complex property's propery and complex property has null value
+        // TODO should be 404
+        [InlineData("/People(5)/HomeAddress/Address", 204)]
+        // single complex property's property with null value 
+        [InlineData("/People(6)/HomeAddress/Address", 204)]
+        // collection of complex property with empty collection value
+        [InlineData("/People(5)/Locations", 200)]
+        // collection of complex property's propery and collection of complex property has null value
+        // TODO should be bad request 400 as this is not allowed, 404 is returned by WebApi Route Match method
+        [InlineData("/People(5)/Locations/Address", 404)]
+        // single navigation property with null value
+        // TODO Should be 204, cannot differentiate ~/People(nonexistkey) vs /People(5)/NullSingNav now
+        [InlineData("/People(5)/BestFriend", 404)]
+        // single navigation property's propery and navigation property has null value
+        // TODO should be 404
+        [InlineData("/People(5)/BestFriend/MiddleName", 204)]
+        // single navigation property's property with null value
+        [InlineData("/People(6)/BestFriend/MiddleName", 204)]
+        // collection of navigation property with empty collection value
+        [InlineData("/People(5)/Friends", 200)]
+        // collection of navigation property's property and navigation property has null value
+        // TODO should be bad request 400 as this is not allowed, 404 is returned by WebApi Route Match method
+        [InlineData("/People(5)/Friends/MiddleName", 404)]
+        public void QueryPropertyWithNullValueStatusCode(string url, int expectedCode)
+        {
+            TestGetStatusCodeIs(url, expectedCode);
+        }
+
+        [Theory]
+        // Single primitive property
+        // TODO should be 404
+        [InlineData("/People(15)/MiddleName", 204)]
+        // Single primitive property $value
+        // TODO should be 404
+        [InlineData("/People(15)/MiddleName/$value", 204)]
+        // Collection of primitive property 
+        // TODO should be 404
+        [InlineData("/People(15)/Emails", 200)]
+        // Collection of primitive property $value
+        // TODO should be bad request 400 as this is not allowed, 404 is returned by WebApi Route Match method
+        [InlineData("/People(15)/Emails/$value", 404)]
+        // single complex property
+        // TODO should be 404
+        [InlineData("/People(15)/HomeAddress", 204)]
+        // single complex property's property
+        // TODO should be 404
+        [InlineData("/People(15)/HomeAddress/Address", 204)]
+        // collection of complex property
+        // TODO should be 404
+        [InlineData("/People(15)/Locations", 200)]
+        // collection of complex property's propery
+        // TODO should be bad request 400 as this is not allowed?? 404 is returned by WebApi Route Match method
+        [InlineData("/People(15)/Locations/Address", 404)]
+        // single navigation property
+        [InlineData("/People(15)/BestFriend", 404)]
+        // single navigation property's propery
+        // TODO should be 404
+        [InlineData("/People(15)/BestFriend/MiddleName", 204)]
+        // collection of navigation property
+        // TODO should be 404
+        [InlineData("/People(15)/Friends", 200)]
+        // collection of navigation property's property
+        // TODO should be bad request 400 as this is not allowed, 404 is returned by WebApi Route Match method
+        [InlineData("/People(15)/Friends/MiddleName", 404)]
+        public void QueryPropertyWithNonExistEntity(string url, int expectedCode)
+        {
+            TestGetStatusCodeIs(url, expectedCode);
+        }
     }
 }

--- a/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Services.Trippin/Models/Person.cs
+++ b/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Services.Trippin/Models/Person.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Restier.WebApi.Test.Services.Trippin.Models
 {
     public class Person
     {
+        public virtual Person BestFriend { get; set; }
+
         public virtual ICollection<Person> Friends { get; set; }
 
         public virtual ICollection<Trip> Trips { get; set; }

--- a/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Services.Trippin/Models/TrippinModel.cs
+++ b/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Services.Trippin/Models/TrippinModel.cs
@@ -317,6 +317,21 @@ namespace Microsoft.Restier.WebApi.Test.Services.Trippin.Models
                 Friends = new Collection<Person> { person1, person2 }
             };
 
+            var person4 = new Person
+            {
+                PersonId = 4,
+                FirstName = "Javier",
+                UserName = "javieralfred",
+                BirthDate = new DateTime(1985, 1, 10),
+                BirthTime = new TimeSpan(23, 59, 1),
+                BirthDateTime = new DateTime(1985, 1, 10, 23, 59, 1),
+                FavoriteFeature = Feature.Feature4,
+                BirthDate2 = new DateTime(1985, 1, 10),
+                BirthTime2 = new TimeSpan(23, 59, 1),
+                BirthDateTime2 = new DateTime(1985, 1, 10, 23, 59, 1),
+                FavoriteFeature2 = Feature.Feature4,
+            };
+
             person1.Friends = new Collection<Person> { person2 };
             #endregion
 
@@ -325,22 +340,8 @@ namespace Microsoft.Restier.WebApi.Test.Services.Trippin.Models
                 person1,
                 person2,
                 person3,
+                person4,
 
-                new Person
-                {
-                    PersonId = 4,
-                    FirstName = "Javier",
-                    LastName = "Alfred",
-                    UserName = "javieralfred",
-                    BirthDate = new DateTime(1985, 1, 10),
-                    BirthTime = new TimeSpan(23, 59, 1),
-                    BirthDateTime = new DateTime(1985, 1, 10, 23, 59, 1),
-                    FavoriteFeature = Feature.Feature4,
-                    BirthDate2 = new DateTime(1985, 1, 10),
-                    BirthTime2 = new TimeSpan(23, 59, 1),
-                    BirthDateTime2 = new DateTime(1985, 1, 10, 23, 59, 1),
-                    FavoriteFeature2 = Feature.Feature4,
-                },
                 new Person
                 {
                     PersonId = 5,
@@ -351,6 +352,8 @@ namespace Microsoft.Restier.WebApi.Test.Services.Trippin.Models
                     BirthTime = new TimeSpan(22, 58, 2),
                     BirthDateTime = new DateTime(1986, 2, 9, 22, 58, 2),
                     FavoriteFeature = Feature.Feature1,
+                    BestFriend = person4,
+                    Friends = new Collection<Person>()
                 },
                 new Person
                 {
@@ -362,6 +365,8 @@ namespace Microsoft.Restier.WebApi.Test.Services.Trippin.Models
                     BirthTime = new TimeSpan(21, 57, 3),
                     BirthDateTime = new DateTime(1987, 3, 8, 21, 57, 3),
                     FavoriteFeature = Feature.Feature2,
+                    BestFriend = person4,
+                    Friends = new Collection<Person>()
                 },
                 new Person
                 {

--- a/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Services.TrippinInMemory/Models/Person.cs
+++ b/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Services.TrippinInMemory/Models/Person.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Restier.WebApi.Test.Services.TrippinInMemory
 {
     public class Person
     {
+        public Person BestFriend { get; set; }
+
         // Way 1: enable auto-expand through attribute.
         [AutoExpand]
         public virtual ICollection<Person> Friends { get; set; }
@@ -24,6 +26,8 @@ namespace Microsoft.Restier.WebApi.Test.Services.TrippinInMemory
 
         [MaxLength(26), MinLength(1)]
         public string LastName { get; set; }
+        
+        public string MiddleName { get; set; }
 
         public long Concurrency { get; set; }
 
@@ -33,6 +37,8 @@ namespace Microsoft.Restier.WebApi.Test.Services.TrippinInMemory
         public Feature FavoriteFeature { get; set; }
 
         public virtual ICollection<string> Emails { get; set; }
+        
+        public Location HomeAddress { get; set; }
 
         public virtual ICollection<Location> Locations { get; set; } 
 

--- a/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Services.TrippinInMemory/Models/TrippinApi.cs
+++ b/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Services.TrippinInMemory/Models/TrippinApi.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Restier.WebApi.Test.Services.TrippinInMemory
                     "u1@trippin.com",
                     "u1@odata.org"
                 },
+                HomeAddress = new Location { Address = "ccc1" },
                 Locations = new Collection<Location>
                 {
                     new Location { Address = "a1" },
@@ -98,6 +99,37 @@ namespace Microsoft.Restier.WebApi.Test.Services.TrippinInMemory
                     Feature.Feature4,
                     Feature.Feature1
                 }
+            },
+            new Person
+            {
+                PersonId = 5,
+                FirstName = "u4",
+                FavoriteFeature = Feature.Feature4,
+                Emails = new Collection<string>(),
+                Features = new Collection<Feature>(),
+                Locations = new Collection<Location>()
+            },
+            new Person
+            {
+                PersonId = 6,
+                FirstName = "u4",
+                FavoriteFeature = Feature.Feature4,
+                Emails = new Collection<string>
+                {
+                    "u4@trippin.com",
+                    "u4@odata.org"
+                },
+                HomeAddress = new Location(),
+                Locations = new Collection<Location>
+                {
+                    new Location { Address = "a4" },
+                    new Location { Address = "b4" }
+                },
+                Features = new Collection<Feature>
+                {
+                    Feature.Feature4,
+                    Feature.Feature1
+                }
             }
         };
 
@@ -107,6 +139,10 @@ namespace Microsoft.Restier.WebApi.Test.Services.TrippinInMemory
             people[1].Friends = new Collection<Person> { people[2], people[3] };
             people[2].Friends = new Collection<Person> { people[3], people[0] };
             people[3].Friends = new Collection<Person> { people[0], people[1] };
+            people[4].Friends = new Collection<Person>();
+            people[5].Friends = new Collection<Person>();
+
+            people[5].BestFriend = people[4];
         }
 
         public IQueryable<Person> People


### PR DESCRIPTION
This is for issue #305 

Issue found: 
1. Incorrect path like collection/$valuewill return 404 but not 400 (badrequest), this is handled by WebApi
2. Null single value will return 200 but not 204
3. Null complex and request complex property will have 500 (NullReferenceException )
4. Null single navigation request will return 500

Issues which are not fixed yet
1. Incorrect path like collection/$value will return 404 but not 400 (badrequest), this is handled by WebApi. Tracked with OData/WebApi#683
2. Request single navigation property with null value return 404 now as cannot differentiate ~/People(nonexistkey) (404) vs /People(5)/NullSingNav (204) now. Tracked with Issue #288
3. Request with non-existing entity's prop will return 204 /200, should be 404. Tracked with Issue #328 
4. Null collection is not handled yet, if collection is null, 500 will be returned (EF only allow navigation collection). Tracked with Issue #330

Issues fixed with this issue:
1. For single value of primitive/complex/enum, will return 204 now (was 200)
2. For request single navigation property or its property will return 404 (was 500)
For request of complex property and complex is null, will return based on prop (204 or 200), but not 500.