### PR TITLE
Make null collection of primitive/enum/complex return correct code

### DIFF
--- a/src/Microsoft.Restier.WebApi/RestierController.cs
+++ b/src/Microsoft.Restier.WebApi/RestierController.cs
@@ -401,7 +401,7 @@ namespace Microsoft.Restier.WebApi
             {
                 // TODO GitHubIssue#288: 204 expected when requesting single nav propery which has null value
                 // ~/People(nonexistkey) and ~/People(nonexistkey)/BestFriend, expected 404
-                // ~/People(key)/BestFriend, abd BestFriend is null, expected 204
+                // ~/People(key)/BestFriend, and BestFriend is null, expected 204
                 throw new HttpResponseException(
                     this.Request.CreateErrorResponse(
                         HttpStatusCode.NotFound,

--- a/test/Microsoft.Restier.Samples.Northwind.Tests/Microsoft.Restier.Samples.Northwind.Tests.csproj
+++ b/test/Microsoft.Restier.Samples.Northwind.Tests/Microsoft.Restier.Samples.Northwind.Tests.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -17,6 +16,8 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -84,12 +85,16 @@
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.core, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/test/Microsoft.Restier.Samples.Northwind.Tests/packages.config
+++ b/test/Microsoft.Restier.Samples.Northwind.Tests/packages.config
@@ -9,9 +9,10 @@
   <package id="Microsoft.OData.Edm" version="6.15.0-beta" targetFramework="net45" />
   <package id="Microsoft.Spatial" version="6.15.0-beta" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
-  <package id="xunit" version="2.0.0" targetFramework="net45" />
+  <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.assert" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.core" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
 </packages>

--- a/test/Microsoft.Restier.TestCommon/Microsoft.Restier.TestCommon.csproj
+++ b/test/Microsoft.Restier.TestCommon/Microsoft.Restier.TestCommon.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -11,6 +10,8 @@
     <AssemblyName>Microsoft.Restier.TestCommon</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -42,12 +43,16 @@
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.core, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -85,8 +90,8 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props'))" />
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
     <Error Condition="!Exists('..\..\packages\xunit.MSBuild.2.0.0.0\build\xunit.MSBuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.MSBuild.2.0.0.0\build\xunit.MSBuild.targets'))" />
+    <Error Condition="!Exists('..\..\packages\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/test/Microsoft.Restier.TestCommon/packages.config
+++ b/test/Microsoft.Restier.TestCommon/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.0.0" targetFramework="net452" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />
-  <package id="xunit.assert" version="2.0.0" targetFramework="net452" />
-  <package id="xunit.core" version="2.0.0" targetFramework="net452" />
-  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net452" />
-  <package id="xunit.MSBuild" version="2.0.0.0" targetFramework="net452" developmentDependency="true" />
-  <package id="xunit.runner.visualstudio" version="2.0.1" targetFramework="net452" />
   <package id="Microsoft.OData.StyleCop" version="1.0.0" />
-  <package id="StyleCop.MSBuild" version="4.7.49" />
+  <package id="StyleCop.MSBuild" version="4.7.49.0" targetFramework="net45" developmentDependency="true" />
+  <package id="xunit" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.MSBuild" version="2.0.0.0" targetFramework="net452" developmentDependency="true" />
 </packages>

--- a/test/Microsoft.Restier.WebApi.Test/Microsoft.Restier.WebApi.Test.csproj
+++ b/test/Microsoft.Restier.WebApi.Test/Microsoft.Restier.WebApi.Test.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -17,6 +16,8 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -74,12 +75,16 @@
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.core, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/test/Microsoft.Restier.WebApi.Test/packages.config
+++ b/test/Microsoft.Restier.WebApi.Test/packages.config
@@ -8,10 +8,10 @@
   <package id="Microsoft.OData.Edm" version="6.15.0-beta" targetFramework="net45" />
   <package id="Microsoft.Spatial" version="6.15.0-beta" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
-  <package id="xunit" version="2.0.0" targetFramework="net45" />
+  <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.assert" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.core" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.extensions" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
 </packages>

--- a/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Scenario/TrippinInMemoryE2ETest.cs
+++ b/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Scenario/TrippinInMemoryE2ETest.cs
@@ -38,6 +38,8 @@ namespace Microsoft.Restier.WebApi.Test.Scenario
         {
             TestGetPayloadContains("People(1)/Emails",
                 "\"@odata.context\":\"http://localhost:21248/api/Trippin/$metadata#Collection(Edm.String)\"");
+            TestGetPayloadContains("People(7)/Emails",
+                "\"value\":[");
         }
 
         [Fact]
@@ -84,7 +86,7 @@ namespace Microsoft.Restier.WebApi.Test.Scenario
         }
 
         [Theory]
-        // Note, null collection of any type (primitive/enum/Complex/navCollection) is not tested.
+        // Note, null collection of any type (navCollection) is not tested as EF Query Executor does not support comparision of ICollection.
         // Single primitive property with null value 
         [InlineData("/People(5)/MiddleName", 204)]
         // Single primitive property $value with null value 
@@ -94,6 +96,8 @@ namespace Microsoft.Restier.WebApi.Test.Scenario
         // Collection of primitive property $value with null value, should throw exception
         // TODO should be bad request 400 as this is not allowed, 404 is returned by WebApi Route Match method
         [InlineData("/People(5)/Emails/$value", 404)]
+        // Collection of primitive property with null collection
+        [InlineData("/People(7)/Emails", 200)]
         // single complex property with null value
         [InlineData("/People(5)/HomeAddress", 204)]
         // single complex property's propery and complex property has null value
@@ -106,6 +110,8 @@ namespace Microsoft.Restier.WebApi.Test.Scenario
         // collection of complex property's propery and collection of complex property has null value
         // TODO should be bad request 400 as this is not allowed, 404 is returned by WebApi Route Match method
         [InlineData("/People(5)/Locations/Address", 404)]
+        // Collection of primitive property with null collection
+        [InlineData("/People(7)/Locations", 200)]
         // single navigation property with null value
         // TODO Should be 204, cannot differentiate ~/People(nonexistkey) vs /People(5)/NullSingNav now
         [InlineData("/People(5)/BestFriend", 404)]

--- a/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Services.TrippinInMemory/Models/TrippinApi.cs
+++ b/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Services.TrippinInMemory/Models/TrippinApi.cs
@@ -130,6 +130,13 @@ namespace Microsoft.Restier.WebApi.Test.Services.TrippinInMemory
                     Feature.Feature4,
                     Feature.Feature1
                 }
+            },
+            new Person
+            {
+                PersonId = 7,
+                FirstName = "u4",
+                FavoriteFeature = Feature.Feature4,
+                HomeAddress = new Location()
             }
         };
 
@@ -141,6 +148,7 @@ namespace Microsoft.Restier.WebApi.Test.Services.TrippinInMemory
             people[3].Friends = new Collection<Person> { people[0], people[1] };
             people[4].Friends = new Collection<Person>();
             people[5].Friends = new Collection<Person>();
+            people[6].Friends = new Collection<Person>();
 
             people[5].BestFriend = people[4];
         }


### PR DESCRIPTION
Partially fix issue of #330 , will return empty collection when collection is null on server side for primitive type/enum/complex,  and nav property collection is not fixed as EF does not support to have collection!=null in LINQ.