### PR TITLE
Remove ChangeSet.AnEntityHasChanged and related logic

### DIFF
--- a/src/GlobalSuppressions.cs
+++ b/src/GlobalSuppressions.cs
@@ -96,7 +96,7 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.Core.Conventions.ConventionBasedApiModelBuilder+ModelMapper.#InnerModelMapper")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.Core.Submit.DataModificationEntry.#ServerValues")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.EntityFramework.Query.QueryExecutor.#Inner")]
-[assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.WebApi.Query.ODataQueryExecutor.#Inner")]
+[assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.WebApi.Query.RestierQueryExecutor.#Inner")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "System.Linq.Expressions.ExpressionHelperMethods.#QueryableSelectGeneric")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "System.Linq.Expressions.ExpressionHelperMethods.#QueryableSelectManyGeneric")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "System.Linq.Expressions.ExpressionHelpers.#Select(System.Linq.IQueryable,System.Linq.Expressions.LambdaExpression)")]
@@ -178,7 +178,7 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.Core.Conventions.ConventionBasedApiModelBuilder+QueryExpressionSourcer")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.Core.Conventions.ConventionBasedApiModelBuilder+ModelBuilder")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.Core.Conventions.ConventionBasedApiModelBuilder+ModelMapper")]
-[assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.WebApi.Query.ODataQueryExecutorOptions")]
+[assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.WebApi.Query.RestierQueryExecutorOptions")]
 #endregion
 
 #endregion

--- a/src/Microsoft.Restier.Core/Properties/Resources.Designer.cs
+++ b/src/Microsoft.Restier.Core/Properties/Resources.Designer.cs
@@ -160,15 +160,6 @@ namespace Microsoft.Restier.Core.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Saving the change set has terminated to prevent potential stack overflow.  There have been entity changes and/or creates that have continuously spawn entity changes and/or creates..
-        /// </summary>
-        internal static string ErrorInVerifyingNoEntityHasChanged {
-            get {
-                return ResourceManager.GetString("ErrorInVerifyingNoEntityHasChanged", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Expander cannot change the expression type..
         /// </summary>
         internal static string ExpanderCannotChangeExpressionType {

--- a/src/Microsoft.Restier.Core/Properties/Resources.resx
+++ b/src/Microsoft.Restier.Core/Properties/Resources.resx
@@ -150,9 +150,6 @@
   <data name="ElementTypeNotMatch" xml:space="preserve">
     <value>Element type not match.</value>
   </data>
-  <data name="ErrorInVerifyingNoEntityHasChanged" xml:space="preserve">
-    <value>Saving the change set has terminated to prevent potential stack overflow.  There have been entity changes and/or creates that have continuously spawn entity changes and/or creates.</value>
-  </data>
   <data name="ExpanderCannotChangeExpressionType" xml:space="preserve">
     <value>Expander cannot change the expression type.</value>
   </data>

--- a/src/Microsoft.Restier.Core/Submit/ChangeSet.cs
+++ b/src/Microsoft.Restier.Core/Submit/ChangeSet.cs
@@ -49,11 +49,5 @@ namespace Microsoft.Restier.Core.Submit
                 return this.entries;
             }
         }
-
-        /// TODO GitHubIssue#37 : make the ChangeSet 'dynamic' so it gets added to as things change during the flow.
-        /// <summary>
-        /// Gets or sets a value indicating whether an Entity has been added, modified, or deleted.
-        /// </summary>
-        public bool AnEntityHasChanged { get; set; }
     }
 }

--- a/src/Microsoft.Restier.WebApi/HttpConfigurationExtensions.cs
+++ b/src/Microsoft.Restier.WebApi/HttpConfigurationExtensions.cs
@@ -49,8 +49,8 @@ namespace Microsoft.Restier.WebApi
 
             ApiConfiguration.Configure<TApi>(services =>
             {
-                services.AddScoped<ODataQueryExecutorOptions>()
-                    .ChainPrevious<IQueryExecutor, ODataQueryExecutor>();
+                services.AddScoped<RestierQueryExecutorOptions>()
+                    .ChainPrevious<IQueryExecutor, RestierQueryExecutor>();
             });
             using (var api = apiFactory())
             {

--- a/src/Microsoft.Restier.WebApi/Microsoft.Restier.WebApi.csproj
+++ b/src/Microsoft.Restier.WebApi/Microsoft.Restier.WebApi.csproj
@@ -90,7 +90,7 @@
     <Compile Include="Formatter\Serialization\RestierFeedSerializer.cs" />
     <Compile Include="HttpConfigurationExtensions.cs" />
     <Compile Include="HttpRequestMessageExtensions.cs" />
-    <Compile Include="Query\ODataQueryExecutor.cs" />
+    <Compile Include="Query\RestierQueryExecutor.cs" />
     <Compile Include="RestierQueryBuilder.cs" />
     <Compile Include="Extensions.cs" />
     <Compile Include="RestierFormattingAttribute.cs" />
@@ -120,7 +120,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>SharedResources.resx</DependentUpon>
     </Compile>
-    <Compile Include="Query\ODataQueryExecutorOptions.cs" />
+    <Compile Include="Query\RestierQueryExecutorOptions.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Restier.Core\Microsoft.Restier.Core.csproj">

--- a/src/Microsoft.Restier.WebApi/Query/RestierQueryExecutor.cs
+++ b/src/Microsoft.Restier.WebApi/Query/RestierQueryExecutor.cs
@@ -9,7 +9,7 @@ using Microsoft.Restier.Core.Query;
 
 namespace Microsoft.Restier.WebApi.Query
 {
-    internal class ODataQueryExecutor : IQueryExecutor
+    internal class RestierQueryExecutor : IQueryExecutor
     {
         public IQueryExecutor Inner { get; set; }
 
@@ -18,7 +18,7 @@ namespace Microsoft.Restier.WebApi.Query
             IQueryable<TElement> query,
             CancellationToken cancellationToken)
         {
-            var countOption = context.ApiContext.GetApiService<ODataQueryExecutorOptions>();
+            var countOption = context.ApiContext.GetApiService<RestierQueryExecutorOptions>();
             if (countOption.IncludeTotalCount)
             {
                 var countQuery = ExpressionHelpers.GetCountableQuery(query);

--- a/src/Microsoft.Restier.WebApi/Query/RestierQueryExecutorOptions.cs
+++ b/src/Microsoft.Restier.WebApi/Query/RestierQueryExecutorOptions.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.Restier.WebApi.Query
 {
-    internal class ODataQueryExecutorOptions
+    internal class RestierQueryExecutorOptions
     {
         /// <summary>
         /// Gets or sets a value indicating whether the total

--- a/src/Microsoft.Restier.WebApi/RestierController.cs
+++ b/src/Microsoft.Restier.WebApi/RestierController.cs
@@ -456,9 +456,10 @@ namespace Microsoft.Restier.WebApi
 
             if (queryOptions.Count != null)
             {
-                ODataQueryExecutorOptions context = Api.Context.GetApiService<ODataQueryExecutorOptions>();
-                context.IncludeTotalCount = queryOptions.Count.Value;
-                context.SetTotalCount = value => properties.TotalCount = value;
+                RestierQueryExecutorOptions queryExecutorOptions =
+                    Api.Context.GetApiService<RestierQueryExecutorOptions>();
+                queryExecutorOptions.IncludeTotalCount = queryOptions.Count.Value;
+                queryExecutorOptions.SetTotalCount = value => properties.TotalCount = value;
             }
 
             // Entity count can NOT be evaluated at this point of time because the source

--- a/test/Microsoft.Restier.TestCommon/PublicApi.bsl
+++ b/test/Microsoft.Restier.TestCommon/PublicApi.bsl
@@ -552,7 +552,6 @@ public class Microsoft.Restier.Core.Submit.ChangeSet {
 	public ChangeSet ()
 	public ChangeSet (System.Collections.Generic.IEnumerable`1[[Microsoft.Restier.Core.Submit.ChangeSetEntry]] entries)
 
-	bool AnEntityHasChanged  { [CompilerGeneratedAttribute(),]public get; [CompilerGeneratedAttribute(),]public set; }
 	System.Collections.Generic.IList`1[[Microsoft.Restier.Core.Submit.ChangeSetEntry]] Entries  { public get; }
 }
 


### PR DESCRIPTION
This PR fixes #321.

We are removing `ChangeSetAnEntityHasChanged` and the related logic in `DefaultSubmitHandler` because:

 - The current concurrency logic in `DefaultSubmitHandler` is hard to read and vulnerable. How do we determine the inner loop count and the outer loop count exactly?
 - Currently there is no concurrency between changeset addition and changeset submission according to the implementation of `RestierChangeSetProperty`. If we do have this need, we can have a more robust design later.
 - For now, the simplest code offers the best performance.