### PR TITLE
Rename ODataQueryExecutor to RestierQueryExecutor

### DIFF
--- a/src/Microsoft.Restier.WebApi/HttpConfigurationExtensions.cs
+++ b/src/Microsoft.Restier.WebApi/HttpConfigurationExtensions.cs
@@ -49,8 +49,8 @@ namespace Microsoft.Restier.WebApi
 
             ApiConfiguration.Configure<TApi>(services =>
             {
-                services.AddScoped<ODataQueryExecutorOptions>()
-                    .ChainPrevious<IQueryExecutor, ODataQueryExecutor>();
+                services.AddScoped<RestierQueryExecutorOptions>()
+                    .ChainPrevious<IQueryExecutor, RestierQueryExecutor>();
             });
             using (var api = apiFactory())
             {

--- a/src/Microsoft.Restier.WebApi/Microsoft.Restier.WebApi.csproj
+++ b/src/Microsoft.Restier.WebApi/Microsoft.Restier.WebApi.csproj
@@ -90,7 +90,7 @@
     <Compile Include="Formatter\Serialization\RestierFeedSerializer.cs" />
     <Compile Include="HttpConfigurationExtensions.cs" />
     <Compile Include="HttpRequestMessageExtensions.cs" />
-    <Compile Include="Query\ODataQueryExecutor.cs" />
+    <Compile Include="Query\RestierQueryExecutor.cs" />
     <Compile Include="RestierQueryBuilder.cs" />
     <Compile Include="Extensions.cs" />
     <Compile Include="RestierFormattingAttribute.cs" />
@@ -120,7 +120,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>SharedResources.resx</DependentUpon>
     </Compile>
-    <Compile Include="Query\ODataQueryExecutorOptions.cs" />
+    <Compile Include="Query\RestierQueryExecutorOptions.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Restier.Core\Microsoft.Restier.Core.csproj">

--- a/src/Microsoft.Restier.WebApi/Query/RestierQueryExecutor.cs
+++ b/src/Microsoft.Restier.WebApi/Query/RestierQueryExecutor.cs
@@ -9,7 +9,7 @@ using Microsoft.Restier.Core.Query;
 
 namespace Microsoft.Restier.WebApi.Query
 {
-    internal class ODataQueryExecutor : IQueryExecutor
+    internal class RestierQueryExecutor : IQueryExecutor
     {
         public IQueryExecutor Inner { get; set; }
 
@@ -18,7 +18,7 @@ namespace Microsoft.Restier.WebApi.Query
             IQueryable<TElement> query,
             CancellationToken cancellationToken)
         {
-            var countOption = context.ApiContext.GetApiService<ODataQueryExecutorOptions>();
+            var countOption = context.ApiContext.GetApiService<RestierQueryExecutorOptions>();
             if (countOption.IncludeTotalCount)
             {
                 var countQuery = ExpressionHelpers.GetCountableQuery(query);

--- a/src/Microsoft.Restier.WebApi/Query/RestierQueryExecutorOptions.cs
+++ b/src/Microsoft.Restier.WebApi/Query/RestierQueryExecutorOptions.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.Restier.WebApi.Query
 {
-    internal class ODataQueryExecutorOptions
+    internal class RestierQueryExecutorOptions
     {
         /// <summary>
         /// Gets or sets a value indicating whether the total

--- a/src/Microsoft.Restier.WebApi/RestierController.cs
+++ b/src/Microsoft.Restier.WebApi/RestierController.cs
@@ -456,9 +456,10 @@ namespace Microsoft.Restier.WebApi
 
             if (queryOptions.Count != null)
             {
-                ODataQueryExecutorOptions context = Api.Context.GetApiService<ODataQueryExecutorOptions>();
-                context.IncludeTotalCount = queryOptions.Count.Value;
-                context.SetTotalCount = value => properties.TotalCount = value;
+                RestierQueryExecutorOptions queryExecutorOptions =
+                    Api.Context.GetApiService<RestierQueryExecutorOptions>();
+                queryExecutorOptions.IncludeTotalCount = queryOptions.Count.Value;
+                queryExecutorOptions.SetTotalCount = value => properties.TotalCount = value;
             }
 
             // Entity count can NOT be evaluated at this point of time because the source


### PR DESCRIPTION
Based on our offline discussion, we will currently keep consistent with the existing classes. We may consider new names for all the publisher classes once we start to implement a new publisher project.