### PR TITLE
Add customizer to ApiConfiguration.

### DIFF
--- a/src/Microsoft.Restier.EntityFramework/DbApi.cs
+++ b/src/Microsoft.Restier.EntityFramework/DbApi.cs
@@ -60,15 +60,10 @@ namespace Microsoft.Restier.EntityFramework
         protected override IServiceCollection ConfigureApi(IServiceCollection services)
         {
             return base.ConfigureApi(services)
-                .CutoffPrevious<IModelBuilder>(ModelProducer.Instance)
-                .CutoffPrevious<IModelMapper>(new ModelMapper(typeof(T)))
-                .CutoffPrevious<IQueryExpressionSourcer, QueryExpressionSourcer>()
-                .ChainPrevious<IQueryExecutor, QueryExecutor>()
-                .CutoffPrevious<IChangeSetPreparer, ChangeSetPreparer>()
-                .CutoffPrevious<ISubmitExecutor>(SubmitExecutor.Instance)
                 .AddScoped<T>(sp =>
                 {
-                    var dbContext = this.CreateDbContext(sp);
+                    var instance = (DbApi<T>)sp.GetService<ApiBase>();
+                    var dbContext = instance.CreateDbContext(sp);
 #if EF7
                     // TODO GitHubIssue#58: Figure out the equivalent measurement to suppress proxy generation in EF7.
 #else
@@ -76,7 +71,7 @@ namespace Microsoft.Restier.EntityFramework
 #endif
                     return dbContext;
                 })
-                .AddScoped<DbContext>(sp => sp.GetService<T>());
+                .UseDbContext<T>();
         }
 
         /// <summary>

--- a/src/Microsoft.Restier.EntityFramework/Microsoft.Restier.EntityFramework.csproj
+++ b/src/Microsoft.Restier.EntityFramework/Microsoft.Restier.EntityFramework.csproj
@@ -64,6 +64,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>SharedResources.resx</DependentUpon>
     </Compile>
+    <Compile Include="ServiceCollectionExtensions.cs" />
     <Compile Include="DbApi.cs" />
     <Compile Include="Model\ModelMapper.cs" />
     <Compile Include="Model\ModelProducer.cs" />

--- a/src/Microsoft.Restier.EntityFramework/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Restier.EntityFramework/ServiceCollectionExtensions.cs
@@ -1,0 +1,36 @@
+﻿using System;
+#if EF7
+using Microsoft.Data.Entity;
+#else
+using System.Data.Entity;
+#endif
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Restier.Core;
+using Microsoft.Restier.Core.Model;
+using Microsoft.Restier.Core.Query;
+using Microsoft.Restier.Core.Submit;
+using Microsoft.Restier.EntityFramework.Model;
+using Microsoft.Restier.EntityFramework.Query;
+using Microsoft.Restier.EntityFramework.Submit;
+
+namespace Microsoft.Restier.EntityFramework
+{
+    [CLSCompliant(false)]
+    public static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection UseDbContext<T>(this IServiceCollection obj)
+            where T : DbContext
+        {
+            obj.TryAddScoped<T>();
+            obj.TryAddScoped(typeof(DbContext), sp => sp.GetService<T>());
+            return obj
+                .CutoffPrevious<IModelBuilder>(ModelProducer.Instance)
+                .CutoffPrevious<IModelMapper>(new ModelMapper(typeof(T)))
+                .CutoffPrevious<IQueryExpressionSourcer, QueryExpressionSourcer>()
+                .ChainPrevious<IQueryExecutor, QueryExecutor>()
+                .CutoffPrevious<IChangeSetPreparer, ChangeSetPreparer>()
+                .CutoffPrevious<ISubmitExecutor>(SubmitExecutor.Instance);
+        }
+    }
+}

--- a/src/Microsoft.Restier.EntityFramework7/Microsoft.Restier.EntityFramework7.csproj
+++ b/src/Microsoft.Restier.EntityFramework7/Microsoft.Restier.EntityFramework7.csproj
@@ -119,6 +119,9 @@
     <Compile Include="..\Microsoft.Restier.EntityFramework\Query\QueryExpressionSourcer.cs">
       <Link>Query.Shared\QueryExpressionSourcer.cs</Link>
     </Compile>
+    <Compile Include="..\Microsoft.Restier.EntityFramework\ServiceCollectionExtensions.cs">
+      <Link>ServiceCollectionExtensions.cs</Link>
+    </Compile>
     <Compile Include="..\Microsoft.Restier.EntityFramework\Submit\SubmitExecutor.cs">
       <Link>Submit.Shared\SubmitExecutor.cs</Link>
     </Compile>

--- a/src/Microsoft.Restier.WebApi/HttpConfigurationExtensions.cs
+++ b/src/Microsoft.Restier.WebApi/HttpConfigurationExtensions.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Restier.WebApi
             Ensure.NotNull(apiFactory, "apiFactory");
 
             // ApiBase.ConfigureApi is called before this method is called.
-            ApiConfiguration.Configure<TApi>(services =>
+            ApiConfiguration.Customize<TApi>().PrivateApi.Append(services =>
             {
                 services.AddScoped<RestierQueryExecutorOptions>()
                     .ChainPrevious<IQueryExecutor, RestierQueryExecutor>();


### PR DESCRIPTION
- Enable customizing ApiConfiguration at 4 anchors.
- ApiBase will draw configurations from customizer when creating ApiConfiguration.
- Introduce a new overridable (ConfigureApiServices) to ApiBase, which gives descendants more freedom to choose from service sets.