### PR TITLE
A more flexible configuration system

### DIFF
--- a/src/Microsoft.Restier.Core/Api.Interfaces.cs
+++ b/src/Microsoft.Restier.Core/Api.Interfaces.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Restier.Core
+{
+    [CLSCompliant(false)]
+    public interface IApiConfigurator
+    {
+        void Configure(IServiceCollection services, Type apiType);
+    }
+
+    public interface IApiInitializer
+    {
+        void Initialize(ApiConfiguration configuration);
+    }
+
+    public interface IApiContextConfigurator
+    {
+        void Initialize(ApiContext context);
+
+        void Cleanup(ApiContext context);
+    }
+
+    [CLSCompliant(false)]
+    public interface IApiContextFactory
+    {
+        ApiContext CreateWithin(IServiceScope scope);
+    }
+}

--- a/src/Microsoft.Restier.Core/ApiConfiguration.cs
+++ b/src/Microsoft.Restier.Core/ApiConfiguration.cs
@@ -72,6 +72,16 @@ namespace Microsoft.Restier.Core
             return configurations.GetOrAdd(keyType, _ => new Customizer());
         }
 
+        [CLSCompliant(false)]
+        public static ApiConfiguration Create(Action<IServiceCollection> configurationCall)
+        {
+            return new ServiceCollection()
+                .DefaultInnerMost()
+                .Apply(configurationCall)
+                .DefaultOuterMost()
+                .BuildApiConfiguration();
+        }
+
         internal TaskCompletionSource<IEdmModel> CompeteModelGeneration(out Task<IEdmModel> running)
         {
             var source = new TaskCompletionSource<IEdmModel>(TaskCreationOptions.AttachedToParent);

--- a/src/Microsoft.Restier.Core/ApiConfigurationExtensions.cs
+++ b/src/Microsoft.Restier.Core/ApiConfigurationExtensions.cs
@@ -122,6 +122,22 @@ namespace Microsoft.Restier.Core
 
         #endregion
 
+        [CLSCompliant(false)]
+        public static ApiContext CreateContextWithin(this ApiConfiguration obj, IServiceScope scope)
+        {
+            return obj.GetApiService<IApiContextFactory>().CreateWithin(scope);
+        }
+
+        /// <summary>
+        /// Creates an <see cref="ApiContext"/> configured by current <see cref="ApiConfiguration"/>.
+        /// </summary>
+        /// <param name="obj">The <see cref="ApiConfiguration"/>.</param>
+        /// <returns>An <see cref="ApiContext"/>.</returns>
+        public static ApiContext CreateContext(this ApiConfiguration obj)
+        {
+            return obj.CreateContextWithin(obj.GetApiService<IServiceScopeFactory>().CreateScope());
+        }
+
         #region IgnoreProperty
 
         /// <summary>

--- a/src/Microsoft.Restier.Core/ApiContextExtensions.cs
+++ b/src/Microsoft.Restier.Core/ApiContextExtensions.cs
@@ -159,6 +159,13 @@ namespace Microsoft.Restier.Core
 
         #endregion
 
+        public static ApiContext CreateNew(this ApiContext obj)
+        {
+            var sp = obj.ServiceProvider;
+            return sp.GetService<IApiContextFactory>().CreateWithin(
+                sp.GetService<IServiceScopeFactory>().CreateScope());
+        }
+
         #region Model
 
         /// <summary>

--- a/src/Microsoft.Restier.Core/Conventions/ConventionBasedApiModelBuilder.cs
+++ b/src/Microsoft.Restier.Core/Conventions/ConventionBasedApiModelBuilder.cs
@@ -95,9 +95,9 @@ namespace Microsoft.Restier.Core.Conventions
                 object target = null;
                 if (!entitySetProperty.GetMethod.IsStatic)
                 {
-                    target = context.QueryContext.GetApiService<ApiBase>();
-                    if (target == null ||
-                        !this.targetType.IsInstanceOfType(target))
+                    target = context.QueryContext.ApiContext
+                        .ServiceProvider.GetService(targetType);
+                    if (target == null)
                     {
                         return null;
                     }
@@ -136,9 +136,9 @@ namespace Microsoft.Restier.Core.Conventions
                 object target = null;
                 if (!singletonProperty.GetMethod.IsStatic)
                 {
-                    target = context.QueryContext.GetApiService<ApiBase>();
-                    if (target == null ||
-                        !this.targetType.IsInstanceOfType(target))
+                    target = context.QueryContext.ApiContext
+                        .ServiceProvider.GetService(targetType);
+                    if (target == null)
                     {
                         return null;
                     }

--- a/src/Microsoft.Restier.Core/Conventions/ConventionBasedChangeSetAuthorizer.cs
+++ b/src/Microsoft.Restier.Core/Conventions/ConventionBasedChangeSetAuthorizer.cs
@@ -54,9 +54,9 @@ namespace Microsoft.Restier.Core.Conventions
                 object target = null;
                 if (!method.IsStatic)
                 {
-                    target = context.GetApiService<ApiBase>();
-                    if (target == null ||
-                        !this.targetType.IsInstanceOfType(target))
+                    target = context.ApiContext
+                        .ServiceProvider.GetService(targetType);
+                    if (target == null)
                     {
                         return Task.FromResult(result);
                     }

--- a/src/Microsoft.Restier.Core/Conventions/ConventionBasedChangeSetEntryFilter.cs
+++ b/src/Microsoft.Restier.Core/Conventions/ConventionBasedChangeSetEntryFilter.cs
@@ -130,9 +130,9 @@ namespace Microsoft.Restier.Core.Conventions
                 object target = null;
                 if (!method.IsStatic)
                 {
-                    target = context.GetApiService<ApiBase>();
-                    if (target == null ||
-                        !this.targetType.IsInstanceOfType(target))
+                    target = context.ApiContext
+                        .ServiceProvider.GetService(targetType);
+                    if (target == null)
                     {
                         return Task.WhenAll();
                     }

--- a/src/Microsoft.Restier.Core/Conventions/ConventionBasedEntitySetFilter.cs
+++ b/src/Microsoft.Restier.Core/Conventions/ConventionBasedEntitySetFilter.cs
@@ -64,9 +64,9 @@ namespace Microsoft.Restier.Core.Conventions
                 object target = null;
                 if (!method.IsStatic)
                 {
-                    target = context.QueryContext.GetApiService<ApiBase>();
-                    if (target == null ||
-                        !this.targetType.IsInstanceOfType(target))
+                    target = context.QueryContext.ApiContext
+                        .ServiceProvider.GetService(targetType);
+                    if (target == null)
                     {
                         return null;
                     }

--- a/src/Microsoft.Restier.Core/Microsoft.Restier.Core.csproj
+++ b/src/Microsoft.Restier.Core/Microsoft.Restier.Core.csproj
@@ -111,6 +111,7 @@
     <Compile Include="Submit\ValidationSeverity.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Api.Interfaces.cs" />
     <None Include="Microsoft.Restier.Core.nuspec" />
     <None Include="packages.config">
       <SubType>Designer</SubType>

--- a/src/Microsoft.Restier.Core/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Restier.Core/ServiceCollectionExtensions.cs
@@ -294,14 +294,56 @@ namespace Microsoft.Restier.Core
 
             var serviceProvider = serviceProviderFactory != null ?
                 serviceProviderFactory(obj) : obj.BuildServiceProvider();
-            return serviceProvider.GetService<ApiConfiguration>();
+            var configuration = serviceProvider.GetService<ApiConfiguration>();
+
+            foreach (var e in serviceProvider.GetServices<IApiInitializer>())
+            {
+                e.Initialize(configuration);
+            }
+
+            return configuration;
+        }
+
+        public static IServiceCollection DefaultInnerMost(this IServiceCollection obj)
+        {
+            return obj.CutoffPrevious<IApiContextFactory, ApiContextFactory>()
+                .CutoffPrevious<IQueryExecutor>(DefaultQueryExecutor.Instance)
+                .AddScoped<PropertyBag>();
+        }
+
+        public static IServiceCollection DefaultOuterMost(this IServiceCollection obj)
+        {
+            obj.ChainPrevious<IApiContextFactory, ApiContextInitializer>();
+            if (!obj.HasService<ApiContext>())
+            {
+                obj.AddScoped<ContextHolder>()
+                    .AddScoped(sp => sp.GetService<ContextHolder>().Context);
+            }
+
+            return obj;
         }
 
         public static IServiceCollection UseAttributes(this IServiceCollection obj, Type apiType)
         {
-            Ensure.NotNull(apiType, "apiType");
+            Ensure.NotNull(apiType, "type");
 
-            ApiConfiguratorAttribute.ApplyApiServices(apiType, obj);
+            if (apiType.BaseType != null)
+            {
+                obj = obj.UseAttributes(apiType.BaseType);
+            }
+
+            var attributes = apiType.GetCustomAttributes(
+                typeof(IApiConfigurator), false);
+            if (attributes.Length == 0)
+            {
+                return obj;
+            }
+
+            foreach (IApiConfigurator e in attributes)
+            {
+                e.Configure(obj, apiType);
+            }
+
             return obj;
         }
 
@@ -402,6 +444,42 @@ namespace Microsoft.Restier.Core
             }
 
             return null;
+        }
+
+        private class ApiContextFactory : IApiContextFactory
+        {
+            public ApiContext CreateWithin(IServiceScope scope)
+            {
+                var context = new ApiContext(scope);
+                var holder = context.GetApiService<ContextHolder>();
+                if (holder != null)
+                {
+                    holder.Context = context;
+                }
+
+                return context;
+            }
+        }
+
+        private class ApiContextInitializer : IApiContextFactory
+        {
+            public IApiContextFactory Inner { get; set; }
+
+            public ApiContext CreateWithin(IServiceScope scope)
+            {
+                var context = Inner.CreateWithin(scope);
+                foreach (var e in context.GetApiServices<IApiContextConfigurator>())
+                {
+                    e.Initialize(context);
+                }
+
+                return context;
+            }
+        }
+
+        private class ContextHolder
+        {
+            public ApiContext Context { get; set; }
         }
     }
 

--- a/src/Microsoft.Restier.EntityFramework/DbApi.cs
+++ b/src/Microsoft.Restier.EntityFramework/DbApi.cs
@@ -60,15 +60,10 @@ namespace Microsoft.Restier.EntityFramework
         protected override IServiceCollection ConfigureApi(IServiceCollection services)
         {
             return base.ConfigureApi(services)
-                .CutoffPrevious<IModelBuilder>(ModelProducer.Instance)
-                .CutoffPrevious<IModelMapper>(new ModelMapper(typeof(T)))
-                .CutoffPrevious<IQueryExpressionSourcer, QueryExpressionSourcer>()
-                .ChainPrevious<IQueryExecutor, QueryExecutor>()
-                .CutoffPrevious<IChangeSetPreparer, ChangeSetPreparer>()
-                .CutoffPrevious<ISubmitExecutor>(SubmitExecutor.Instance)
                 .AddScoped<T>(sp =>
                 {
-                    var dbContext = this.CreateDbContext(sp);
+                    var instance = (DbApi<T>)sp.GetService<ApiBase>();
+                    var dbContext = instance.CreateDbContext(sp);
 #if EF7
                     // TODO GitHubIssue#58: Figure out the equivalent measurement to suppress proxy generation in EF7.
 #else
@@ -76,7 +71,7 @@ namespace Microsoft.Restier.EntityFramework
 #endif
                     return dbContext;
                 })
-                .AddScoped<DbContext>(sp => sp.GetService<T>());
+                .UseDbContext<T>();
         }
 
         /// <summary>

--- a/src/Microsoft.Restier.EntityFramework/Microsoft.Restier.EntityFramework.csproj
+++ b/src/Microsoft.Restier.EntityFramework/Microsoft.Restier.EntityFramework.csproj
@@ -64,6 +64,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>SharedResources.resx</DependentUpon>
     </Compile>
+    <Compile Include="ServiceCollectionExtensions.cs" />
     <Compile Include="DbApi.cs" />
     <Compile Include="Model\ModelMapper.cs" />
     <Compile Include="Model\ModelProducer.cs" />

--- a/src/Microsoft.Restier.EntityFramework/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Restier.EntityFramework/ServiceCollectionExtensions.cs
@@ -1,0 +1,36 @@
+﻿using System;
+#if EF7
+using Microsoft.Data.Entity;
+#else
+using System.Data.Entity;
+#endif
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Restier.Core;
+using Microsoft.Restier.Core.Model;
+using Microsoft.Restier.Core.Query;
+using Microsoft.Restier.Core.Submit;
+using Microsoft.Restier.EntityFramework.Model;
+using Microsoft.Restier.EntityFramework.Query;
+using Microsoft.Restier.EntityFramework.Submit;
+
+namespace Microsoft.Restier.EntityFramework
+{
+    [CLSCompliant(false)]
+    public static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection UseDbContext<T>(this IServiceCollection obj)
+            where T : DbContext
+        {
+            obj.TryAddScoped<T>();
+            obj.TryAddScoped(typeof(DbContext), sp => sp.GetService<T>());
+            return obj
+                .CutoffPrevious<IModelBuilder>(ModelProducer.Instance)
+                .CutoffPrevious<IModelMapper>(new ModelMapper(typeof(T)))
+                .CutoffPrevious<IQueryExpressionSourcer, QueryExpressionSourcer>()
+                .ChainPrevious<IQueryExecutor, QueryExecutor>()
+                .CutoffPrevious<IChangeSetPreparer, ChangeSetPreparer>()
+                .CutoffPrevious<ISubmitExecutor>(SubmitExecutor.Instance);
+        }
+    }
+}

--- a/src/Microsoft.Restier.EntityFramework7/Microsoft.Restier.EntityFramework7.csproj
+++ b/src/Microsoft.Restier.EntityFramework7/Microsoft.Restier.EntityFramework7.csproj
@@ -119,6 +119,9 @@
     <Compile Include="..\Microsoft.Restier.EntityFramework\Query\QueryExpressionSourcer.cs">
       <Link>Query.Shared\QueryExpressionSourcer.cs</Link>
     </Compile>
+    <Compile Include="..\Microsoft.Restier.EntityFramework\ServiceCollectionExtensions.cs">
+      <Link>ServiceCollectionExtensions.cs</Link>
+    </Compile>
     <Compile Include="..\Microsoft.Restier.EntityFramework\Submit\SubmitExecutor.cs">
       <Link>Submit.Shared\SubmitExecutor.cs</Link>
     </Compile>

--- a/src/Microsoft.Restier.Security/ApiConfigurationExtensions.cs
+++ b/src/Microsoft.Restier.Security/ApiConfigurationExtensions.cs
@@ -34,8 +34,28 @@ namespace Microsoft.Restier.Security
             this IServiceCollection services)
         {
             Ensure.NotNull(services, "services");
-            services.CutoffPrevious<IQueryExpressionInspector, RoleBasedAuthorizer>();
-            services.ChainPrevious<IQueryExpressionExpander, ApiPolicyActivator>();
+            if (!services.HasService<RoleBasedAuthorizer>())
+            {
+                services.CutoffPrevious<IQueryExpressionInspector, RoleBasedAuthorizer>();
+            }
+        }
+
+        [CLSCompliant(false)]
+        public static void EnableApiPolicy(
+            this IServiceCollection services, Type apiType)
+        {
+            Ensure.NotNull(services, "services");
+            services.ChainPrevious<IQueryExpressionExpander>(next => new ApiPolicyActivator(apiType)
+            {
+                InnerHandler = next,
+            });
+        }
+
+        [CLSCompliant(false)]
+        public static void EnableApiPolicy<T>(this IServiceCollection services)
+            where T : class
+        {
+            services.EnableApiPolicy(typeof(T));
         }
     }
 }

--- a/src/Microsoft.Restier.Security/ApiPolicyActivator.cs
+++ b/src/Microsoft.Restier.Security/ApiPolicyActivator.cs
@@ -16,6 +16,13 @@ namespace Microsoft.Restier.Security
     /// </summary>
     public class ApiPolicyActivator : IQueryExpressionExpander
     {
+        private Type targetType;
+
+        public ApiPolicyActivator(Type targetType)
+        {
+            this.targetType = targetType;
+        }
+
         /// <inheritdoc/>
         public IQueryExpressionExpander InnerHandler { get; set; }
 
@@ -50,8 +57,7 @@ namespace Microsoft.Restier.Security
                 return CallInner(context);
             }
 
-            var target = context.QueryContext.GetApiService<ApiBase>();
-            var entitySetProperty = target.GetType().GetProperties(
+            var entitySetProperty = targetType.GetProperties(
                 BindingFlags.Public | BindingFlags.Instance |
                 BindingFlags.Static | BindingFlags.DeclaredOnly)
                 .SingleOrDefault(p => p.Name == entitySet.Name);

--- a/src/Microsoft.Restier.Security/EnableRoleBasedSecurityAttribute.cs
+++ b/src/Microsoft.Restier.Security/EnableRoleBasedSecurityAttribute.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Restier.Security
             Type type)
         {
             services.EnableRoleBasedSecurity();
+            services.EnableApiPolicy(type);
         }
     }
 }

--- a/src/Microsoft.Restier.WebApi/Batch/RestierBatchHandler.cs
+++ b/src/Microsoft.Restier.WebApi/Batch/RestierBatchHandler.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Restier.WebApi.Batch
         /// </summary>
         /// <param name="httpServer">The HTTP server instance.</param>
         /// <param name="apiFactory">Gets or sets the callback to create API.</param>
-        public RestierBatchHandler(HttpServer httpServer, Func<ApiBase> apiFactory = null)
+        public RestierBatchHandler(HttpServer httpServer, Func<ApiContext> apiFactory = null)
             : base(httpServer)
         {
             this.ApiFactory = apiFactory;
@@ -34,7 +34,7 @@ namespace Microsoft.Restier.WebApi.Batch
         /// <summary>
         /// Gets or sets the callback to create API.
         /// </summary>
-        public Func<ApiBase> ApiFactory { get; set; }
+        public Func<ApiContext> ApiFactory { get; set; }
 
         /// <summary>
         /// Asynchronously parses the batch requests.

--- a/src/Microsoft.Restier.WebApi/Batch/RestierChangeSetRequestItem.cs
+++ b/src/Microsoft.Restier.WebApi/Batch/RestierChangeSetRequestItem.cs
@@ -17,14 +17,14 @@ namespace Microsoft.Restier.WebApi.Batch
     /// </summary>
     public class RestierChangeSetRequestItem : ChangeSetRequestItem
     {
-        private Func<ApiBase> apiFactory;
+        private Func<ApiContext> apiFactory;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RestierChangeSetRequestItem" /> class.
         /// </summary>
         /// <param name="requests">The request messages.</param>
         /// <param name="apiFactory">Gets or sets the callback to create API.</param>
-        public RestierChangeSetRequestItem(IEnumerable<HttpRequestMessage> requests, Func<ApiBase> apiFactory)
+        public RestierChangeSetRequestItem(IEnumerable<HttpRequestMessage> requests, Func<ApiContext> apiFactory)
             : base(requests)
         {
             Ensure.NotNull(apiFactory, "apiFactory");

--- a/src/Microsoft.Restier.WebApi/HttpConfigurationExtensions.cs
+++ b/src/Microsoft.Restier.WebApi/HttpConfigurationExtensions.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Restier.WebApi
             Ensure.NotNull(apiFactory, "apiFactory");
 
             // ApiBase.ConfigureApi is called before this method is called.
-            ApiConfiguration.Configure<TApi>(services =>
+            ApiConfiguration.Customize<TApi>().PrivateApi.Append(services =>
             {
                 services.AddScoped<RestierQueryExecutorOptions>()
                     .ChainPrevious<IQueryExecutor, RestierQueryExecutor>();

--- a/src/Microsoft.Restier.WebApi/HttpConfigurationExtensions.cs
+++ b/src/Microsoft.Restier.WebApi/HttpConfigurationExtensions.cs
@@ -41,9 +41,9 @@ namespace Microsoft.Restier.WebApi
             this HttpConfiguration config,
             string routeName,
             string routePrefix,
-            Func<ApiBase> apiFactory,
+            Func<ApiContext> apiFactory,
             RestierBatchHandler batchHandler = null)
-            where TApi : ApiBase
+            where TApi : class
         {
             Ensure.NotNull(apiFactory, "apiFactory");
 
@@ -68,7 +68,7 @@ namespace Microsoft.Restier.WebApi
                     routeName, routePrefix, model, new DefaultODataPathHandler(), conventions, batchHandler);
 
                 // Customized converter should be added in ConfigureApi as service
-                var converter = api.Context.GetApiService<ODataPayloadValueConverter>();
+                var converter = api.GetApiService<ODataPayloadValueConverter>();
                 if (converter == null)
                 {
                     converter = new RestierPayloadValueConverter();
@@ -97,7 +97,7 @@ namespace Microsoft.Restier.WebApi
             where TApi : ApiBase, new()
         {
             return MapRestierRoute<TApi>(
-                config, routeName, routePrefix, () => new TApi(), batchHandler);
+                config, routeName, routePrefix, () => new TApi().Context, batchHandler);
         }
 
         /// <summary>
@@ -108,7 +108,7 @@ namespace Microsoft.Restier.WebApi
         /// <param name="apiFactory">The API factory.</param>
         /// <returns>The routing conventions created.</returns>
         private static IList<IODataRoutingConvention> CreateRestierRoutingConventions(
-            this HttpConfiguration config, IEdmModel model, Func<ApiBase> apiFactory)
+            this HttpConfiguration config, IEdmModel model, Func<ApiContext> apiFactory)
         {
             var conventions = ODataRoutingConventions.CreateDefaultWithAttributeRouting(config, model);
             var index = 0;

--- a/src/Microsoft.Restier.WebApi/HttpRequestMessageExtensions.cs
+++ b/src/Microsoft.Restier.WebApi/HttpRequestMessageExtensions.cs
@@ -41,14 +41,14 @@ namespace Microsoft.Restier.WebApi
         /// </summary>
         /// <param name="request">The HTTP request.</param>
         /// <returns>The API factory.</returns>
-        internal static Func<ApiBase> GetApiFactory(this HttpRequestMessage request)
+        internal static Func<ApiContext> GetApiFactory(this HttpRequestMessage request)
         {
             Ensure.NotNull(request, "request");
 
             object value;
             if (request.Properties.TryGetValue(ApiFactoryKey, out value))
             {
-                return value as Func<ApiBase>;
+                return value as Func<ApiContext>;
             }
 
             return null;
@@ -59,7 +59,7 @@ namespace Microsoft.Restier.WebApi
         /// </summary>
         /// <param name="request">The HTTP request.</param>
         /// <param name="apiFactory">The API factory.</param>
-        internal static void SetApiFactory(this HttpRequestMessage request, Func<ApiBase> apiFactory)
+        internal static void SetApiFactory(this HttpRequestMessage request, Func<ApiContext> apiFactory)
         {
             Ensure.NotNull(request, "request");
             Ensure.NotNull(apiFactory, "apiFactory");

--- a/src/Microsoft.Restier.WebApi/RestierController.cs
+++ b/src/Microsoft.Restier.WebApi/RestierController.cs
@@ -40,14 +40,14 @@ namespace Microsoft.Restier.WebApi
         private const string ETagGetterKey = "ETagGetter";
         private const string ETagHeaderKey = "@etag";
 
-        private ApiBase api;
+        private ApiContext api;
         private bool shouldReturnCount;
         private bool shouldWriteRawValue;
 
         /// <summary>
         /// Gets the API associated with this controller.
         /// </summary>
-        public ApiBase Api
+        public ApiContext Api
         {
             get
             {
@@ -82,7 +82,7 @@ namespace Microsoft.Restier.WebApi
             };
             QueryResult queryResult = await Api.QueryAsync(queryRequest, cancellationToken);
 
-            this.Request.Properties[ETagGetterKey] = this.Api.Context.GetProperty(ETagGetterKey);
+            this.Request.Properties[ETagGetterKey] = this.Api.GetProperty(ETagGetterKey);
 
             return this.CreateQueryResponse(queryResult.Results.AsQueryable(), path.EdmType);
         }
@@ -336,13 +336,13 @@ namespace Microsoft.Restier.WebApi
             {
                 if (this.shouldReturnCount || this.shouldWriteRawValue)
                 {
-                    var rawResult = new RawResult(query, typeReference, this.Api.Context);
+                    var rawResult = new RawResult(query, typeReference, this.Api);
                     singleResult = rawResult;
                     response = this.Request.CreateResponse(HttpStatusCode.OK, rawResult);
                 }
                 else
                 {
-                    var primitiveResult = new PrimitiveResult(query, typeReference, this.Api.Context);
+                    var primitiveResult = new PrimitiveResult(query, typeReference, this.Api);
                     singleResult = primitiveResult;
                     response = this.Request.CreateResponse(HttpStatusCode.OK, primitiveResult);
                 }
@@ -350,7 +350,7 @@ namespace Microsoft.Restier.WebApi
 
             if (typeReference.IsComplex())
             {
-                var complexResult = new ComplexResult(query, typeReference, this.Api.Context);
+                var complexResult = new ComplexResult(query, typeReference, this.Api);
                 singleResult = complexResult;
                 response = this.Request.CreateResponse(HttpStatusCode.OK, complexResult);
             }
@@ -359,13 +359,13 @@ namespace Microsoft.Restier.WebApi
             {
                 if (this.shouldWriteRawValue)
                 {
-                    var rawResult = new RawResult(query, typeReference, this.Api.Context);
+                    var rawResult = new RawResult(query, typeReference, this.Api);
                     singleResult = rawResult;
                     response = this.Request.CreateResponse(HttpStatusCode.OK, rawResult);
                 }
                 else
                 {
-                    var enumResult = new EnumResult(query, typeReference, this.Api.Context);
+                    var enumResult = new EnumResult(query, typeReference, this.Api);
                     singleResult = enumResult;
                     response = this.Request.CreateResponse(HttpStatusCode.OK, enumResult);
                 }
@@ -389,14 +389,14 @@ namespace Microsoft.Restier.WebApi
                 if (elementType.IsPrimitive() || elementType.IsComplex() || elementType.IsEnum())
                 {
                     return this.Request.CreateResponse(
-                        HttpStatusCode.OK, new NonEntityCollectionResult(query, typeReference, this.Api.Context));
+                        HttpStatusCode.OK, new NonEntityCollectionResult(query, typeReference, this.Api));
                 }
 
                 return this.Request.CreateResponse(
-                    HttpStatusCode.OK, new EntityCollectionResult(query, typeReference, this.Api.Context));
+                    HttpStatusCode.OK, new EntityCollectionResult(query, typeReference, this.Api));
             }
 
-            var entityResult = new EntityResult(query, typeReference, this.Api.Context);
+            var entityResult = new EntityResult(query, typeReference, this.Api);
             if (entityResult.Result == null)
             {
                 // TODO GitHubIssue#288: 204 expected when requesting single nav propery which has null value
@@ -457,7 +457,7 @@ namespace Microsoft.Restier.WebApi
             if (queryOptions.Count != null)
             {
                 RestierQueryExecutorOptions queryExecutorOptions =
-                    Api.Context.GetApiService<RestierQueryExecutorOptions>();
+                    Api.GetApiService<RestierQueryExecutorOptions>();
                 queryExecutorOptions.IncludeTotalCount = queryOptions.Count.Value;
                 queryExecutorOptions.SetTotalCount = value => properties.TotalCount = value;
             }

--- a/src/Microsoft.Restier.WebApi/RestierQueryBuilder.cs
+++ b/src/Microsoft.Restier.WebApi/RestierQueryBuilder.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Restier.WebApi
         private const char EntityKeySeparator = ',';
         private const char EntityKeyNameValueSeparator = '=';
 
-        private readonly ApiBase api;
+        private readonly ApiContext api;
         private readonly ODataPath path;
         private readonly IDictionary<string, Action<ODataPathSegment>> handlers =
             new Dictionary<string, Action<ODataPathSegment>>();
@@ -30,7 +30,7 @@ namespace Microsoft.Restier.WebApi
         private IEdmEntityType currentEntityType;
         private Type currentType;
 
-        public RestierQueryBuilder(ApiBase api, ODataPath path)
+        public RestierQueryBuilder(ApiContext api, ODataPath path)
         {
             Ensure.NotNull(api, "api");
             Ensure.NotNull(path, "path");

--- a/src/Microsoft.Restier.WebApi/Routing/RestierRoutingConvention.cs
+++ b/src/Microsoft.Restier.WebApi/Routing/RestierRoutingConvention.cs
@@ -22,13 +22,13 @@ namespace Microsoft.Restier.WebApi.Routing
         private const string MethodNameOfGet = "Get";
         private const string MethodNameOfPostAction = "PostAction";
 
-        private readonly Func<ApiBase> apiFactory;
+        private readonly Func<ApiContext> apiFactory;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RestierRoutingConvention" /> class.
         /// </summary>
         /// <param name="apiFactory">The API factory method.</param>
-        public RestierRoutingConvention(Func<ApiBase> apiFactory)
+        public RestierRoutingConvention(Func<ApiContext> apiFactory)
         {
             this.apiFactory = apiFactory;
         }

--- a/test/ODataEndToEndTests/Microsoft.Restier.Samples.Northwind/App_Start/WebApiConfig.cs
+++ b/test/ODataEndToEndTests/Microsoft.Restier.Samples.Northwind/App_Start/WebApiConfig.cs
@@ -1,8 +1,19 @@
 ﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Web.Http;
+using System.Web.OData;
 using System.Web.OData.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Library;
+using Microsoft.Restier.Core;
+using Microsoft.Restier.Core.Model;
+using Microsoft.Restier.EntityFramework;
 using Microsoft.Restier.Samples.Northwind.Models;
 using Microsoft.Restier.WebApi;
 using Microsoft.Restier.WebApi.Batch;
@@ -34,6 +45,50 @@ namespace Microsoft.Restier.Samples.Northwind
             config.MapRestierRoute<NorthwindApi>(
                 "NorthwindApi", "api/Northwind",
                 new RestierBatchHandler(server));
+
+            var configuration = new Lazy<ApiConfiguration>(
+                BuildNorthwind2Configuration, LazyThreadSafetyMode.ExecutionAndPublication);
+            config.MapRestierRoute<NorthwindApi2>(
+                "NorthwindApi2", "api/Northwind2",
+                () => configuration.Value.CreateContext(),
+                new RestierBatchHandler(server));
+        }
+
+        private static ApiConfiguration BuildNorthwind2Configuration()
+        {
+            return ApiConfiguration.Create(services =>
+            {
+                var customizer = ApiConfiguration.Customize<NorthwindApi2>();
+                services
+                    .Apply(customizer.InnerMost)
+                    .AddScoped<NorthwindApi2>()
+                    .UseDbContext<NorthwindContext>()
+                    .ChainPrevious<IModelBuilder, NorthwindModelExtender>()
+                    .Apply(customizer.PrivateApi)
+                    .UseAttributes<NorthwindApi2>()
+                    .UseConventions<NorthwindApi2>()
+                    .Apply(customizer.Overrides)
+                    .Apply(customizer.OuterMost);
+            });
+        }
+
+        private class NorthwindModelExtender : IModelBuilder
+        {
+            public IModelBuilder InnerHandler { get; set; }
+
+            public async Task<IEdmModel> GetModelAsync(InvocationContext context, CancellationToken cancellationToken)
+            {
+                var model = await InnerHandler.GetModelAsync(context, cancellationToken);
+
+                // Way 2: enable auto-expand through model annotation.
+                var orderType = (EdmEntityType)model.SchemaElements.Single(e => e.Name == "Order");
+                var orderDetailsProperty = (EdmNavigationProperty)orderType.DeclaredProperties
+                    .Single(prop => prop.Name == "Order_Details");
+                model.SetAnnotationValue(orderDetailsProperty,
+                    new QueryableRestrictionsAnnotation(new QueryableRestrictions { AutoExpand = true }));
+
+                return model;
+            }
         }
     }
 }


### PR DESCRIPTION
This is to give the consuming part more flexibility on configuration.
This change is **based on** #353, which introduces customizer and 4 anchors to configuration system. So #353 is relatively conservative and this one is more aggressive, but **full compatibility is guaranteed**. This is still addition to current system, no breaking to existing consumer.
Comparing to #353, this one adds features enabling fully customized configuration, and making ApiBase optional. The cost is wider public surface, to support new features.
So if we decide that ApiBase is mandatory, we could stop here and consider #353 instead.
- Enable creating ApiContext without ApiBase, i.e. any type could be API types.
- Add methods and extensions to ease ApiConfiguration creation, especially for ApiBase-free scenario.
- Introduce some configuration interfaces, which are important to ApiBase-free configuration, and are compatible to ApiBase configuration.
- Adapt ApiConfiguratorAttribute to the new configuration interfaces.
- Conventions are changed to be able to target Api types other than ApiBase.
- Make ApiContext the main entry point, since in provider code, we actually only need ApiContext. Now that ApiBase is registered as a service, its disposal could be properly handled by service container, we don't have to keep an instance of ApiBase. Of course ApiBase is still an optional entry point.
- Add NorthwindApi2 to demonstrate the new configuration system.
- All UTs still pass, even if targeting Northwind tests at NorthwindApi2.