### PR TITLE
Allow more customization for DI service

### DIFF
--- a/src/GlobalSuppressions.cs
+++ b/src/GlobalSuppressions.cs
@@ -21,7 +21,7 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Microsoft.Usage", "CA2243:AttributeStringLiteralsShouldParseCorrectly", Justification = "AssemblyInformationalVersion could be string.")]
 
 #region CA1004 Generic method with type parameter
-[assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.Core.ApiConfiguration.#Configure`1(System.Action`1<Microsoft.Extensions.DependencyInjection.IServiceCollection>)")]
+[assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.Core.ApiConfiguration.#AddInternalServices`1(System.Action`1<Microsoft.Extensions.DependencyInjection.IServiceCollection>)")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.Core.Query.IQueryExecutor.#ExecuteSingleAsync`1(Microsoft.Restier.Core.Query.QueryContext,System.Linq.IQueryable,System.Linq.Expressions.Expression,System.Threading.CancellationToken)")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.Core.ServiceCollectionExtensions.#HasService`1(Microsoft.Extensions.DependencyInjection.IServiceCollection)")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.Core.ServiceCollectionExtensions.#CutoffPrevious`2(Microsoft.Extensions.DependencyInjection.IServiceCollection)")]
@@ -29,9 +29,10 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.Core.ServiceCollectionExtensions.#MakeSingleton`1(Microsoft.Extensions.DependencyInjection.IServiceCollection)")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.Core.ServiceCollectionExtensions.#MakeScoped`1(Microsoft.Extensions.DependencyInjection.IServiceCollection)")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.Core.ServiceCollectionExtensions.#MakeTransient`1(Microsoft.Extensions.DependencyInjection.IServiceCollection)")]
-[assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.WebApi.HttpConfigurationExtensions.#MapRestierRoute`1(System.Web.Http.HttpConfiguration,System.String,System.String,System.Func`1<Microsoft.Restier.Core.ApiBase>,Microsoft.Restier.WebApi.Batch.RestierBatchHandler)")]
-[assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.WebApi.HttpConfigurationExtensions.#MapRestierRoute`1(System.Web.Http.HttpConfiguration,System.String,System.String,Microsoft.Restier.WebApi.Batch.RestierBatchHandler)")]
-[assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.WebApi.HttpConfigurationExtensions.#CreateRestierRoutingConventions`1(System.Web.Http.HttpConfiguration,Microsoft.OData.Edm.IEdmModel)")]
+[assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.EntityFramework.ServiceCollectionExtensions.#AddDbContextServices`1(Microsoft.Extensions.DependencyInjection.IServiceCollection)")]
+[assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.WebApi.ServiceCollectionExtensions.#AddWebApiServices`1(Microsoft.Extensions.DependencyInjection.IServiceCollection)")]
+[assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.WebApi.Routing.HttpConfigurationExtensions.#MapRestierRoute`1(System.Web.Http.HttpConfiguration,System.String,System.String,System.Func`1<Microsoft.Restier.Core.ApiBase>,Microsoft.Restier.WebApi.Batch.RestierBatchHandler)")]
+[assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.WebApi.Routing.HttpConfigurationExtensions.#MapRestierRoute`1(System.Web.Http.HttpConfiguration,System.String,System.String,Microsoft.Restier.WebApi.Batch.RestierBatchHandler)")]
 #endregion
 
 #region CA1020 Few types in namespace
@@ -64,8 +65,8 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed", Scope = "member", Target = "Microsoft.Restier.Core.Query.QueryResult.#.ctor(System.Collections.IEnumerable,System.Nullable`1<System.Int64>)")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed", Scope = "member", Target = "Microsoft.Restier.Security.ApiPermission.#CreateGrant(System.String,System.String,System.String,System.String,System.String)")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed", Scope = "member", Target = "Microsoft.Restier.Security.ApiPermission.#CreateDeny(System.String,System.String,System.String,System.String,System.String)")]
-[assembly: SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed", Scope = "member", Target = "Microsoft.Restier.WebApi.HttpConfigurationExtensions.#MapRestierRoute`1(System.Web.Http.HttpConfiguration,System.String,System.String,System.Func`1<Microsoft.Restier.Core.ApiBase>,Microsoft.Restier.WebApi.Batch.RestierBatchHandler)")]
-[assembly: SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed", Scope = "member", Target = "Microsoft.Restier.WebApi.HttpConfigurationExtensions.#MapRestierRoute`1(System.Web.Http.HttpConfiguration,System.String,System.String,Microsoft.Restier.WebApi.Batch.RestierBatchHandler)")]
+[assembly: SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed", Scope = "member", Target = "Microsoft.Restier.WebApi.Routing.HttpConfigurationExtensions.#MapRestierRoute`1(System.Web.Http.HttpConfiguration,System.String,System.String,System.Func`1<Microsoft.Restier.Core.ApiBase>,Microsoft.Restier.WebApi.Batch.RestierBatchHandler)")]
+[assembly: SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed", Scope = "member", Target = "Microsoft.Restier.WebApi.Routing.HttpConfigurationExtensions.#MapRestierRoute`1(System.Web.Http.HttpConfiguration,System.String,System.String,Microsoft.Restier.WebApi.Batch.RestierBatchHandler)")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed", Scope = "member", Target = "Microsoft.Restier.WebApi.Batch.RestierBatchHandler.#.ctor(System.Web.Http.HttpServer,System.Func`1<Microsoft.Restier.Core.ApiContext>)")]
 #endregion
 
@@ -88,12 +89,6 @@ using System.Diagnostics.CodeAnalysis;
 
 #region CA1811 Review uncalled private code
 [assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "System.TypeExtensions.#GetQualifiedMethod(System.Type,System.String)")]
-[assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.Core.Conventions.ConventionBasedApiModelBuilder+ModelBuilder.#.ctor(Microsoft.Restier.Core.Conventions.ConventionBasedApiModelBuilder)")]
-[assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.Core.Conventions.ConventionBasedApiModelBuilder+ModelBuilder.#InnerModelBuilder")]
-[assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.Core.Conventions.ConventionBasedApiModelBuilder+ModelBuilder.#ModelCache")]
-[assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.Core.Conventions.ConventionBasedApiModelBuilder+ModelMapper.#ModelCache")]
-[assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.Core.Conventions.ConventionBasedApiModelBuilder+ModelMapper.#.ctor(Microsoft.Restier.Core.Conventions.ConventionBasedApiModelBuilder)")]
-[assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.Core.Conventions.ConventionBasedApiModelBuilder+ModelMapper.#InnerModelMapper")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.Core.Submit.DataModificationEntry.#ServerValues")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.EntityFramework.Query.QueryExecutor.#Inner")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.WebApi.Query.RestierQueryExecutor.#Inner")]
@@ -108,6 +103,12 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.WebApi.Filters.ValidationResultDto.#PropertyName")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.WebApi.Filters.ValidationResultDto.#Message")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.WebApi.Filters.ValidationResultDto.#Id")]
+[assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.WebApi.Model.ApiModelBuilder+ModelBuilder.#.ctor(Microsoft.Restier.WebApi.Model.ApiModelBuilder)")]
+[assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.WebApi.Model.ApiModelBuilder+ModelBuilder.#InnerModelBuilder")]
+[assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.WebApi.Model.ApiModelBuilder+ModelBuilder.#ModelCache")]
+[assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.WebApi.Model.ApiModelBuilder+ModelMapper.#.ctor(Microsoft.Restier.WebApi.Model.ApiModelBuilder)")]
+[assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.WebApi.Model.ApiModelBuilder+ModelMapper.#ModelCache")]
+[assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.WebApi.Model.ApiModelBuilder+ModelMapper.#InnerModelMapper")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "System.Linq.Expressions.ExpressionHelperMethods.#QueryableCountGeneric")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "System.Linq.Expressions.ExpressionHelperMethods.#QueryableWhereGeneric")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "System.Linq.Expressions.ExpressionHelpers.#Where(System.Linq.IQueryable,System.Linq.Expressions.LambdaExpression,System.Type)")]
@@ -174,12 +175,10 @@ using System.Diagnostics.CodeAnalysis;
 #region CA1812 Uninstantiated internal classes
 [assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.Core.ApiBase+ApiHolder")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.Core.Conventions.ConventionBasedChangeSetEntryValidator")]
-[assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.Core.Conventions.ConventionBasedApiModelBuilder+QueryExpressionExpander")]
-[assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.Core.Conventions.ConventionBasedApiModelBuilder+QueryExpressionSourcer")]
-[assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.Core.Conventions.ConventionBasedApiModelBuilder+ModelBuilder")]
-[assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.Core.Conventions.ConventionBasedApiModelBuilder+ModelMapper")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.Core.PropertyBag")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.EntityFramework.Query.QueryExpressionFilter")]
+[assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.WebApi.Model.ApiModelBuilder+QueryExpressionExpander")]
+[assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.WebApi.Model.ApiModelBuilder+QueryExpressionSourcer")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.WebApi.Query.RestierQueryExecutorOptions")]
 #endregion
 

--- a/src/GlobalSuppressions.cs
+++ b/src/GlobalSuppressions.cs
@@ -21,7 +21,7 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Microsoft.Usage", "CA2243:AttributeStringLiteralsShouldParseCorrectly", Justification = "AssemblyInformationalVersion could be string.")]
 
 #region CA1004 Generic method with type parameter
-[assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.Core.ApiConfiguration.#AddInternalServices`1(System.Action`1<Microsoft.Extensions.DependencyInjection.IServiceCollection>)")]
+[assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.Core.ApiConfiguration.#AddPublisherServices`1(System.Action`1<Microsoft.Extensions.DependencyInjection.IServiceCollection>)")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.Core.Query.IQueryExecutor.#ExecuteSingleAsync`1(Microsoft.Restier.Core.Query.QueryContext,System.Linq.IQueryable,System.Linq.Expressions.Expression,System.Threading.CancellationToken)")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.Core.ServiceCollectionExtensions.#HasService`1(Microsoft.Extensions.DependencyInjection.IServiceCollection)")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.Core.ServiceCollectionExtensions.#CutoffPrevious`2(Microsoft.Extensions.DependencyInjection.IServiceCollection)")]
@@ -29,7 +29,7 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.Core.ServiceCollectionExtensions.#MakeSingleton`1(Microsoft.Extensions.DependencyInjection.IServiceCollection)")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.Core.ServiceCollectionExtensions.#MakeScoped`1(Microsoft.Extensions.DependencyInjection.IServiceCollection)")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.Core.ServiceCollectionExtensions.#MakeTransient`1(Microsoft.Extensions.DependencyInjection.IServiceCollection)")]
-[assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.EntityFramework.ServiceCollectionExtensions.#AddDbContextServices`1(Microsoft.Extensions.DependencyInjection.IServiceCollection)")]
+[assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.EntityFramework.ServiceCollectionExtensions.#AddEfProviderServices`1(Microsoft.Extensions.DependencyInjection.IServiceCollection)")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.WebApi.ServiceCollectionExtensions.#AddWebApiServices`1(Microsoft.Extensions.DependencyInjection.IServiceCollection)")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.WebApi.Routing.HttpConfigurationExtensions.#MapRestierRoute`1(System.Web.Http.HttpConfiguration,System.String,System.String,System.Func`1<Microsoft.Restier.Core.ApiBase>,Microsoft.Restier.WebApi.Batch.RestierBatchHandler)")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Scope = "member", Target = "Microsoft.Restier.WebApi.Routing.HttpConfigurationExtensions.#MapRestierRoute`1(System.Web.Http.HttpConfiguration,System.String,System.String,Microsoft.Restier.WebApi.Batch.RestierBatchHandler)")]
@@ -79,6 +79,11 @@ using System.Diagnostics.CodeAnalysis;
 #region CA1704 Identifiers spelling
 [assembly: SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Sourcer", Scope = "type", Target = "Microsoft.Restier.Core.Query.IQueryExpressionSourcer")]
 [assembly: SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Sourcer", Scope = "type", Target = "Microsoft.Restier.EntityFramework.Query.QueryExpressionSourcer")]
+[assembly: SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Ef", Scope = "member", Target = "Microsoft.Restier.EntityFramework.ServiceCollectionExtensions.#AddEfProviderServices`1(Microsoft.Extensions.DependencyInjection.IServiceCollection)")]
+#endregion
+
+#region CA1709 Identifiers case
+[assembly: SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "Ef", Scope = "member", Target = "Microsoft.Restier.EntityFramework.ServiceCollectionExtensions.#AddEfProviderServices`1(Microsoft.Extensions.DependencyInjection.IServiceCollection)")]
 #endregion
 
 #endregion
@@ -103,12 +108,12 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.WebApi.Filters.ValidationResultDto.#PropertyName")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.WebApi.Filters.ValidationResultDto.#Message")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.WebApi.Filters.ValidationResultDto.#Id")]
-[assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.WebApi.Model.ApiModelBuilder+ModelBuilder.#.ctor(Microsoft.Restier.WebApi.Model.ApiModelBuilder)")]
-[assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.WebApi.Model.ApiModelBuilder+ModelBuilder.#InnerModelBuilder")]
-[assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.WebApi.Model.ApiModelBuilder+ModelBuilder.#ModelCache")]
-[assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.WebApi.Model.ApiModelBuilder+ModelMapper.#.ctor(Microsoft.Restier.WebApi.Model.ApiModelBuilder)")]
-[assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.WebApi.Model.ApiModelBuilder+ModelMapper.#ModelCache")]
-[assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.WebApi.Model.ApiModelBuilder+ModelMapper.#InnerModelMapper")]
+[assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.WebApi.Model.RestierModelExtender+ModelBuilder.#.ctor(Microsoft.Restier.WebApi.Model.RestierModelExtender)")]
+[assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.WebApi.Model.RestierModelExtender+ModelBuilder.#InnerModelBuilder")]
+[assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.WebApi.Model.RestierModelExtender+ModelBuilder.#ModelCache")]
+[assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.WebApi.Model.RestierModelExtender+ModelMapper.#.ctor(Microsoft.Restier.WebApi.Model.RestierModelExtender)")]
+[assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.WebApi.Model.RestierModelExtender+ModelMapper.#ModelCache")]
+[assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.Restier.WebApi.Model.RestierModelExtender+ModelMapper.#InnerModelMapper")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "System.Linq.Expressions.ExpressionHelperMethods.#QueryableCountGeneric")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "System.Linq.Expressions.ExpressionHelperMethods.#QueryableWhereGeneric")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "System.Linq.Expressions.ExpressionHelpers.#Where(System.Linq.IQueryable,System.Linq.Expressions.LambdaExpression,System.Type)")]
@@ -177,8 +182,8 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.Core.Conventions.ConventionBasedChangeSetEntryValidator")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.Core.PropertyBag")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.EntityFramework.Query.QueryExpressionFilter")]
-[assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.WebApi.Model.ApiModelBuilder+QueryExpressionExpander")]
-[assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.WebApi.Model.ApiModelBuilder+QueryExpressionSourcer")]
+[assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.WebApi.Model.RestierModelExtender+QueryExpressionExpander")]
+[assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.WebApi.Model.RestierModelExtender+QueryExpressionSourcer")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.WebApi.Query.RestierQueryExecutorOptions")]
 #endregion
 

--- a/src/Microsoft.Restier.Core/ApiBase.cs
+++ b/src/Microsoft.Restier.Core/ApiBase.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Restier.Core
                         apiScope.Api = this;
                     }
 
-                    ApiConfiguratorAttribute.ApplyInitialization(
+                    ApiConfiguratorAttributes.ApplyInitialization(
                         this.GetType(), this, this.apiContext);
                 }
 
@@ -88,7 +88,7 @@ namespace Microsoft.Restier.Core
                         services = this.ConfigureApi(services);
 
                         var configuration = this.CreateApiConfiguration(services);
-                        ApiConfiguratorAttribute.ApplyConfiguration(apiType, configuration);
+                        ApiConfiguratorAttributes.ApplyConfiguration(apiType, configuration);
                         return configuration;
                     });
             }
@@ -112,7 +112,7 @@ namespace Microsoft.Restier.Core
 
             if (this.apiContext != null)
             {
-                ApiConfiguratorAttribute.ApplyDisposal(
+                ApiConfiguratorAttributes.ApplyDisposal(
                     this.GetType(), this, this.apiContext);
             }
 
@@ -134,11 +134,10 @@ namespace Microsoft.Restier.Core
             // Add core and conversion's services
             services = services.AddCoreServices(apiType)
                 .AddAttributeServices(apiType)
-                .AddConventionServices(apiType);
+                .AddConventionBasedServices(apiType);
 
             // This is used to add the publisher's services
-            //TODO, will think about a better way
-            ApiConfiguration.GetInternalServiceCallback(apiType)(services);
+            ApiConfiguration.GetPublisherServiceCallback(apiType)(services);
 
             return services;
         }

--- a/src/Microsoft.Restier.Core/ApiConfiguration.cs
+++ b/src/Microsoft.Restier.Core/ApiConfiguration.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Restier.Core
     /// </remarks>
     public class ApiConfiguration
     {
-        private static ConcurrentDictionary<Type, Action<IServiceCollection>> _internalServicesCallback =
+        private static ConcurrentDictionary<Type, Action<IServiceCollection>> publisherServicesCallback =
             new ConcurrentDictionary<Type, Action<IServiceCollection>>();
 
         private static Action<IServiceCollection> emptyConfig = _ => { };
@@ -73,20 +73,20 @@ namespace Microsoft.Restier.Core
         /// An action that will be called during the configuration of <typeparamref name="TApi"/>.
         /// </param>
         [CLSCompliant(false)]
-        public static void AddInternalServices<TApi>(Action<IServiceCollection> configurationCallback)
+        public static void AddPublisherServices<TApi>(Action<IServiceCollection> configurationCallback)
              where TApi : ApiBase
         {
-            _internalServicesCallback.AddOrUpdate(
+            publisherServicesCallback.AddOrUpdate(
                 typeof(TApi),
                 configurationCallback,
                 (type, existing) => existing + configurationCallback);
         }
 
         [CLSCompliant(false)]
-        public static Action<IServiceCollection> GetInternalServiceCallback(Type apiType)
+        public static Action<IServiceCollection> GetPublisherServiceCallback(Type apiType)
         {
             Action<IServiceCollection> val;
-            if (_internalServicesCallback.TryGetValue(apiType, out val))
+            if (publisherServicesCallback.TryGetValue(apiType, out val))
             {
                 return val;
             }

--- a/src/Microsoft.Restier.Core/ApiConfigurationExtensions.cs
+++ b/src/Microsoft.Restier.Core/ApiConfigurationExtensions.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Restier.Core
 
         #region IgnoreProperty Internal
 
-        internal static bool IsPropertyIgnored(this ApiConfiguration configuration, string propertyName)
+        public static bool IsPropertyIgnored(this ApiConfiguration configuration, string propertyName)
         {
             Ensure.NotNull(configuration, "configuration");
 

--- a/src/Microsoft.Restier.Core/ApiConfiguratorAttribute.cs
+++ b/src/Microsoft.Restier.Core/ApiConfiguratorAttribute.cs
@@ -16,129 +16,6 @@ namespace Microsoft.Restier.Core
     public abstract class ApiConfiguratorAttribute : Attribute
     {
         /// <summary>
-        /// Applies configuration from any API configurator attributes
-        /// specified on an API type to an API services.
-        /// </summary>
-        /// <param name="type">
-        /// An API type.
-        /// </param>
-        /// <param name="services">
-        /// The API services registration.
-        /// </param>
-        [CLSCompliant(false)]
-        public static void ApplyApiServices(
-            Type type, IServiceCollection services)
-        {
-            Ensure.NotNull(type, "type");
-            Ensure.NotNull(services, "services");
-            if (type.BaseType != null)
-            {
-                ApiConfiguratorAttribute.ApplyApiServices(
-                    type.BaseType, services);
-            }
-
-            var attributes = type.GetCustomAttributes(
-                typeof(ApiConfiguratorAttribute), false);
-            foreach (ApiConfiguratorAttribute attribute in attributes)
-            {
-                attribute.ConfigureApi(services, type);
-            }
-        }
-
-        /// <summary>
-        /// Applies configuration from any API configurator attributes
-        /// specified on an API type to an API configuration.
-        /// </summary>
-        /// <param name="type">
-        /// An API type.
-        /// </param>
-        /// <param name="configuration">
-        /// An API configuration.
-        /// </param>
-        public static void ApplyConfiguration(
-            Type type, ApiConfiguration configuration)
-        {
-            Ensure.NotNull(type, "type");
-            Ensure.NotNull(configuration, "configuration");
-            if (type.BaseType != null)
-            {
-                ApiConfiguratorAttribute.ApplyConfiguration(
-                    type.BaseType, configuration);
-            }
-
-            var attributes = type.GetCustomAttributes(
-                typeof(ApiConfiguratorAttribute), false);
-            foreach (ApiConfiguratorAttribute attribute in attributes)
-            {
-                attribute.Configure(configuration, type);
-            }
-        }
-
-        /// <summary>
-        /// Applies initialization routines from any API configurator
-        /// attributes specified on an API type to an API context.
-        /// </summary>
-        /// <param name="type">
-        /// An API type.
-        /// </param>
-        /// <param name="instance">
-        /// An API instance, if applicable.
-        /// </param>
-        /// <param name="context">
-        /// An API context.
-        /// </param>
-        public static void ApplyInitialization(
-            Type type, object instance, ApiContext context)
-        {
-            Ensure.NotNull(type, "type");
-            Ensure.NotNull(context, "context");
-            if (type.BaseType != null)
-            {
-                ApiConfiguratorAttribute.ApplyInitialization(
-                    type.BaseType, instance, context);
-            }
-
-            var attributes = type.GetCustomAttributes(
-                typeof(ApiConfiguratorAttribute), false);
-            foreach (ApiConfiguratorAttribute attribute in attributes)
-            {
-                attribute.Initialize(context, type, instance);
-            }
-        }
-
-        /// <summary>
-        /// Applies disposal routines from any API configurator
-        /// attributes specified on an API type to an API context.
-        /// </summary>
-        /// <param name="type">
-        /// An API type.
-        /// </param>
-        /// <param name="instance">
-        /// An API instance, if applicable.
-        /// </param>
-        /// <param name="context">
-        /// An API context.
-        /// </param>
-        public static void ApplyDisposal(
-            Type type, object instance, ApiContext context)
-        {
-            Ensure.NotNull(type, "type");
-            Ensure.NotNull(context, "context");
-            var attributes = type.GetCustomAttributes(
-                typeof(ApiConfiguratorAttribute), false);
-            foreach (ApiConfiguratorAttribute attribute in attributes.Reverse())
-            {
-                attribute.Dispose(context, type, instance);
-            }
-
-            if (type.BaseType != null)
-            {
-                ApiConfiguratorAttribute.ApplyDisposal(
-                    type.BaseType, instance, context);
-            }
-        }
-
-        /// <summary>
         /// Configures an API services.
         /// </summary>
         /// <param name="services">
@@ -148,7 +25,7 @@ namespace Microsoft.Restier.Core
         /// The API type on which this attribute was placed.
         /// </param>
         [CLSCompliant(false)]
-        public virtual void ConfigureApi(
+        public virtual void AddApiServices(
             IServiceCollection services,
             Type type)
         {

--- a/src/Microsoft.Restier.Core/ApiConfiguratorAttributes.cs
+++ b/src/Microsoft.Restier.Core/ApiConfiguratorAttributes.cs
@@ -1,0 +1,137 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Restier.Core
+{
+    /// <summary>
+    /// Specifies a set of methods that can initialize, configure, add service, dispose for all attributes.
+    /// </summary>
+    internal static class ApiConfiguratorAttributes
+    {
+        /// <summary>
+        /// Applies configuration from any API configurator attributes
+        /// specified on an API type to an API services.
+        /// </summary>
+        /// <param name="type">
+        /// An API type.
+        /// </param>
+        /// <param name="services">
+        /// The API services registration.
+        /// </param>
+        public static void AddApiServices(
+            Type type, IServiceCollection services)
+        {
+            Ensure.NotNull(type, "type");
+            Ensure.NotNull(services, "services");
+            if (type.BaseType != null)
+            {
+                AddApiServices(
+                    type.BaseType, services);
+            }
+
+            var attributes = type.GetCustomAttributes(
+                typeof(ApiConfiguratorAttribute), false);
+            foreach (ApiConfiguratorAttribute attribute in attributes)
+            {
+                attribute.AddApiServices(services, type);
+            }
+        }
+
+        /// <summary>
+        /// Applies configuration from any API configurator attributes
+        /// specified on an API type to an API configuration.
+        /// </summary>
+        /// <param name="type">
+        /// An API type.
+        /// </param>
+        /// <param name="configuration">
+        /// An API configuration.
+        /// </param>
+        public static void ApplyConfiguration(
+            Type type, ApiConfiguration configuration)
+        {
+            Ensure.NotNull(type, "type");
+            Ensure.NotNull(configuration, "configuration");
+            if (type.BaseType != null)
+            {
+                ApplyConfiguration(
+                    type.BaseType, configuration);
+            }
+
+            var attributes = type.GetCustomAttributes(
+                typeof(ApiConfiguratorAttribute), false);
+            foreach (ApiConfiguratorAttribute attribute in attributes)
+            {
+                attribute.Configure(configuration, type);
+            }
+        }
+
+        /// <summary>
+        /// Applies initialization routines from any API configurator
+        /// attributes specified on an API type to an API context.
+        /// </summary>
+        /// <param name="type">
+        /// An API type.
+        /// </param>
+        /// <param name="instance">
+        /// An API instance, if applicable.
+        /// </param>
+        /// <param name="context">
+        /// An API context.
+        /// </param>
+        public static void ApplyInitialization(
+            Type type, object instance, ApiContext context)
+        {
+            Ensure.NotNull(type, "type");
+            Ensure.NotNull(context, "context");
+            if (type.BaseType != null)
+            {
+                ApplyInitialization(
+                    type.BaseType, instance, context);
+            }
+
+            var attributes = type.GetCustomAttributes(
+                typeof(ApiConfiguratorAttribute), false);
+            foreach (ApiConfiguratorAttribute attribute in attributes)
+            {
+                attribute.Initialize(context, type, instance);
+            }
+        }
+
+        /// <summary>
+        /// Applies disposal routines from any API configurator
+        /// attributes specified on an API type to an API context.
+        /// </summary>
+        /// <param name="type">
+        /// An API type.
+        /// </param>
+        /// <param name="instance">
+        /// An API instance, if applicable.
+        /// </param>
+        /// <param name="context">
+        /// An API context.
+        /// </param>
+        public static void ApplyDisposal(
+            Type type, object instance, ApiContext context)
+        {
+            Ensure.NotNull(type, "type");
+            Ensure.NotNull(context, "context");
+            var attributes = type.GetCustomAttributes(
+                typeof(ApiConfiguratorAttribute), false);
+            foreach (ApiConfiguratorAttribute attribute in attributes.Reverse())
+            {
+                attribute.Dispose(context, type, instance);
+            }
+
+            if (type.BaseType != null)
+            {
+                ApplyDisposal(
+                    type.BaseType, instance, context);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Restier.Core/Conventions/ConventionBasedEntitySetFilter.cs
+++ b/src/Microsoft.Restier.Core/Conventions/ConventionBasedEntitySetFilter.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Restier.Core.Conventions
             this.targetType = targetType;
         }
 
+        // Inner should be null unless user add one as inner most 
         public IQueryExpressionFilter Inner { get; set; }
 
         /// <inheritdoc/>

--- a/src/Microsoft.Restier.Core/Microsoft.Restier.Core.csproj
+++ b/src/Microsoft.Restier.Core/Microsoft.Restier.Core.csproj
@@ -38,9 +38,6 @@
       <Link>GlobalSuppressions.cs</Link>
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
-    <Compile Include="..\Shared\EdmHelpers.cs">
-      <Link>Shared\EdmHelpers.cs</Link>
-    </Compile>
     <Compile Include="..\Shared\Ensure.cs">
       <Link>Shared\Ensure.cs</Link>
     </Compile>
@@ -59,9 +56,7 @@
     <Compile Include="Conventions\ConventionBasedChangeSetConstants.cs" />
     <Compile Include="Conventions\ConventionBasedChangeSetEntryFilter.cs" />
     <Compile Include="Conventions\ConventionBasedChangeSetEntryValidator.cs" />
-    <Compile Include="Conventions\ConventionBasedApiModelBuilder.cs" />
     <Compile Include="Conventions\ConventionBasedEntitySetFilter.cs" />
-    <Compile Include="Conventions\ConventionBasedOperationProvider.cs" />
     <Compile Include="ApiBaseExtensions.cs" />
     <Compile Include="ApiBase.cs" />
     <Compile Include="ApiConfiguration.cs" />

--- a/src/Microsoft.Restier.Core/Microsoft.Restier.Core.csproj
+++ b/src/Microsoft.Restier.Core/Microsoft.Restier.Core.csproj
@@ -50,6 +50,7 @@
     <Compile Include="..\Shared\TypeExtensions.cs">
       <Link>Shared\TypeExtensions.cs</Link>
     </Compile>
+    <Compile Include="ApiConfiguratorAttributes.cs" />
     <Compile Include="Model\FunctionAttribute.cs" />
     <Compile Include="Model\ActionAttribute.cs" />
     <Compile Include="Conventions\ConventionBasedChangeSetAuthorizer.cs" />

--- a/src/Microsoft.Restier.Core/Properties/Resources.Designer.cs
+++ b/src/Microsoft.Restier.Core/Properties/Resources.Designer.cs
@@ -248,7 +248,7 @@ namespace Microsoft.Restier.Core.Properties {
                 return ResourceManager.GetString("NoPermissionToUpdateEntity", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Not supported type: {0}..
         /// </summary>

--- a/src/Microsoft.Restier.Core/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Restier.Core/ServiceCollectionExtensions.cs
@@ -38,15 +38,15 @@ namespace Microsoft.Restier.Core
         /// Return true if the <see cref="IServiceCollection"/> has any <typeparamref name="T"/> service registered.
         /// </summary>
         /// <typeparam name="T">The API service type.</typeparam>
-        /// <param name="obj">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <returns>
         /// True if the service is registered.
         /// </returns>
-        public static bool HasService<T>(this IServiceCollection obj) where T : class
+        public static bool HasService<T>(this IServiceCollection services) where T : class
         {
-            Ensure.NotNull(obj, "obj");
+            Ensure.NotNull(services, "services");
 
-            return obj.Any(sd => sd.ServiceType == typeof(T));
+            return services.Any(sd => sd.ServiceType == typeof(T));
         }
 
         /// <summary>
@@ -54,15 +54,15 @@ namespace Microsoft.Restier.Core
         /// <typeparamref name="T"/>.
         /// </summary>
         /// <typeparam name="T">The API service type.</typeparam>
-        /// <param name="obj">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <param name="handler">An instance of type <typeparamref name="T"/>.</param>
         /// <returns>Current <see cref="IServiceCollection"/></returns>
-        public static IServiceCollection CutoffPrevious<T>(this IServiceCollection obj, T handler) where T : class
+        public static IServiceCollection CutoffPrevious<T>(this IServiceCollection services, T handler) where T : class
         {
-            Ensure.NotNull(obj, "obj");
+            Ensure.NotNull(services, "services");
             Ensure.NotNull(handler, "handler");
 
-            return obj.AddContributorNoCheck<T>((sp, next) => handler);
+            return services.AddContributorNoCheck<T>((sp, next) => handler);
         }
 
         /// <summary>
@@ -71,71 +71,71 @@ namespace Microsoft.Restier.Core
         /// </summary>
         /// <typeparam name="TService">The API service type.</typeparam>
         /// <typeparam name="TImplement">The API service implementation type.</typeparam>
-        /// <param name="obj">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <returns>Current <see cref="IServiceCollection"/></returns>
-        public static IServiceCollection CutoffPrevious<TService, TImplement>(this IServiceCollection obj)
+        public static IServiceCollection CutoffPrevious<TService, TImplement>(this IServiceCollection services)
             where TService : class
             where TImplement : class, TService
         {
-            Ensure.NotNull(obj, "obj");
+            Ensure.NotNull(services, "services");
 
-            obj.TryAddTransient<TImplement>();
-            return obj.AddContributorNoCheck<TService>((sp, next) => sp.GetRequiredService<TImplement>());
+            services.TryAddTransient<TImplement>();
+            return services.AddContributorNoCheck<TService>((sp, next) => sp.GetRequiredService<TImplement>());
         }
 
         /// <summary>
         /// Adds a service contributor, which has a chance to chain previously registered service instances.
         /// </summary>
         /// <typeparam name="T">The service type.</typeparam>
-        /// <param name="obj">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <param name="contributor">An instance of <see cref="ApiServiceContributor{T}"/>.</param>
         /// <returns>Current <see cref="IServiceCollection"/></returns>
         public static IServiceCollection AddContributor<T>(
-            this IServiceCollection obj,
+            this IServiceCollection services,
             ApiServiceContributor<T> contributor)
             where T : class
         {
-            Ensure.NotNull(obj, "obj");
+            Ensure.NotNull(services, "services");
             Ensure.NotNull(contributor, "contributor");
 
-            return obj.AddContributorNoCheck<T>(contributor);
+            return services.AddContributorNoCheck<T>(contributor);
         }
 
         /// <summary>
         /// Adds a service contributor, which has a chance to chain previously registered service instances.
         /// </summary>
         /// <typeparam name="T">The service type.</typeparam>
-        /// <param name="obj">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <param name="factory">
         /// A factory method to create a new instance of service T, wrapping previous instance."/>.
         /// </param>
         /// <returns>Current <see cref="IServiceCollection"/></returns>
         public static IServiceCollection ChainPrevious<T>(
-            this IServiceCollection obj,
+            this IServiceCollection services,
             Func<IServiceProvider, T, T> factory)
             where T : class
         {
-            Ensure.NotNull(obj, "obj");
+            Ensure.NotNull(services, "services");
             Ensure.NotNull(factory, "factory");
-            return obj.AddContributorNoCheck<T>((sp, next) => factory(sp, next()));
+            return services.AddContributorNoCheck<T>((sp, next) => factory(sp, next()));
         }
 
         /// <summary>
         /// Adds a service contributor, which has a chance to chain previously registered service instances.
         /// </summary>
         /// <typeparam name="T">The service type.</typeparam>
-        /// <param name="obj">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <param name="factory">
         /// A factory method to create a new instance of service T, wrapping previous instance."/>.
         /// </param>
         /// <returns>Current <see cref="IServiceCollection"/></returns>
         public static IServiceCollection ChainPrevious<T>(
-            this IServiceCollection obj,
+            this IServiceCollection services,
             Func<T, T> factory) where T : class
         {
-            Ensure.NotNull(obj, "obj");
+            Ensure.NotNull(services, "services");
             Ensure.NotNull(factory, "factory");
-            return obj.AddContributorNoCheck<T>((sp, next) => factory(next()));
+            return services.AddContributorNoCheck<T>((sp, next) => factory(next()));
         }
 
         /// <summary>
@@ -154,18 +154,18 @@ namespace Microsoft.Restier.Core
         /// </remarks>
         /// <typeparam name="TService">The service type.</typeparam>
         /// <typeparam name="TImplement">The implementation type.</typeparam>
-        /// <param name="obj">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <returns>Current <see cref="IServiceCollection"/></returns>
-        public static IServiceCollection ChainPrevious<TService, TImplement>(this IServiceCollection obj)
+        public static IServiceCollection ChainPrevious<TService, TImplement>(this IServiceCollection services)
             where TService : class
             where TImplement : class, TService
         {
-            Ensure.NotNull(obj, "obj");
+            Ensure.NotNull(services, "services");
 
             Func<IServiceProvider, Func<TService>, TService> factory = null;
 
-            obj.TryAddTransient<TImplement>();
-            return obj.AddContributorNoCheck<TService>((sp, next) =>
+            services.TryAddTransient<TImplement>();
+            return services.AddContributorNoCheck<TService>((sp, next) =>
             {
                 if (factory != null)
                 {
@@ -230,70 +230,70 @@ namespace Microsoft.Restier.Core
         /// Call this to make singleton lifetime of a service.
         /// </summary>
         /// <typeparam name="T">The service type.</typeparam>
-        /// <param name="obj">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <returns>Current <see cref="IServiceCollection"/></returns>
-        public static IServiceCollection MakeSingleton<T>(this IServiceCollection obj) where T : class
+        public static IServiceCollection MakeSingleton<T>(this IServiceCollection services) where T : class
         {
-            Ensure.NotNull(obj, "obj");
-            obj.AddSingleton<T>(ChainedService<T>.DefaultFactory);
-            return obj;
+            Ensure.NotNull(services, "services");
+            services.AddSingleton<T>(ChainedService<T>.DefaultFactory);
+            return services;
         }
 
         /// <summary>
         /// Call this to make scoped lifetime of a service.
         /// </summary>
         /// <typeparam name="T">The service type.</typeparam>
-        /// <param name="obj">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <returns>Current <see cref="IServiceCollection"/></returns>
-        public static IServiceCollection MakeScoped<T>(this IServiceCollection obj) where T : class
+        public static IServiceCollection MakeScoped<T>(this IServiceCollection services) where T : class
         {
-            Ensure.NotNull(obj, "obj");
-            obj.AddScoped<T>(ChainedService<T>.DefaultFactory);
-            return obj;
+            Ensure.NotNull(services, "services");
+            services.AddScoped<T>(ChainedService<T>.DefaultFactory);
+            return services;
         }
 
         /// <summary>
         /// Call this to make transient lifetime of a service.
         /// </summary>
         /// <typeparam name="T">The service type.</typeparam>
-        /// <param name="obj">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <returns>Current <see cref="IServiceCollection"/></returns>
-        public static IServiceCollection MakeTransient<T>(this IServiceCollection obj) where T : class
+        public static IServiceCollection MakeTransient<T>(this IServiceCollection services) where T : class
         {
-            Ensure.NotNull(obj, "obj");
-            obj.AddTransient<T>(ChainedService<T>.DefaultFactory);
-            return obj;
+            Ensure.NotNull(services, "services");
+            services.AddTransient<T>(ChainedService<T>.DefaultFactory);
+            return services;
         }
 
         /// <summary>
         /// Build the <see cref="ApiConfiguration"/>
         /// </summary>
-        /// <param name="obj">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <returns>The built <see cref="ApiConfiguration"/></returns>
-        public static ApiConfiguration BuildApiConfiguration(this IServiceCollection obj)
+        public static ApiConfiguration BuildApiConfiguration(this IServiceCollection services)
         {
-            return obj.BuildApiConfiguration(null);
+            return services.BuildApiConfiguration(null);
         }
 
         /// <summary>
         /// Build the <see cref="ApiConfiguration"/>
         /// </summary>
-        /// <param name="obj">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <param name="serviceProviderFactory">
         /// An optional factory to create an <see cref="IServiceProvider"/>.
         /// Use this to inject your favorite DI container.
         /// </param>
         /// <returns>The built <see cref="ApiConfiguration"/></returns>
         public static ApiConfiguration BuildApiConfiguration(
-            this IServiceCollection obj,
+            this IServiceCollection services,
             Func<IServiceCollection, IServiceProvider> serviceProviderFactory)
         {
-            Ensure.NotNull(obj, "obj");
+            Ensure.NotNull(services, "services");
 
-            obj.TryAddSingleton<ApiConfiguration>();
+            services.TryAddSingleton<ApiConfiguration>();
 
             var serviceProvider = serviceProviderFactory != null ?
-                serviceProviderFactory(obj) : obj.BuildServiceProvider();
+                serviceProviderFactory(services) : services.BuildServiceProvider();
             return serviceProvider.GetService<ApiConfiguration>();
         }
 
@@ -304,7 +304,7 @@ namespace Microsoft.Restier.Core
         /// service chain registered with <see cref="IServiceCollection"/>.
         /// </summary>
         /// <typeparam name="T">The service type.</typeparam>
-        /// <param name="obj">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <returns>The service instance built.</returns>
         /// <example>
         /// <code>
@@ -312,10 +312,10 @@ namespace Microsoft.Restier.Core
         ///     new SomeService(sp.BuildApiServiceChain &lt; ISomeService &gt;()));
         /// </code>
         /// </example>
-        public static T BuildApiServiceChain<T>(this IServiceProvider obj) where T : class
+        public static T BuildApiServiceChain<T>(this IServiceProvider services) where T : class
         {
-            Ensure.NotNull(obj, "obj");
-            return ChainedService<T>.DefaultFactory(obj);
+            Ensure.NotNull(services, "services");
+            return ChainedService<T>.DefaultFactory(services);
         }
 
         public static IServiceCollection AddCoreServices(this IServiceCollection services, Type apiType)
@@ -339,7 +339,7 @@ namespace Microsoft.Restier.Core
         {
             Ensure.NotNull(apiType, "apiType");
 
-            ApiConfiguratorAttribute.ApplyApiServices(apiType, services);
+            ApiConfiguratorAttributes.AddApiServices(apiType, services);
             return services;
         }
 
@@ -352,7 +352,7 @@ namespace Microsoft.Restier.Core
         /// <param name="apiType">
         /// The type of a class on which code-based conventions are used.
         /// </param>
-        public static IServiceCollection AddConventionServices(this IServiceCollection services, Type apiType)
+        public static IServiceCollection AddConventionBasedServices(this IServiceCollection services, Type apiType)
         {
             Ensure.NotNull(apiType, "apiType");
 
@@ -364,15 +364,15 @@ namespace Microsoft.Restier.Core
         }
 
         private static IServiceCollection AddContributorNoCheck<T>(
-            this IServiceCollection obj,
+            this IServiceCollection services,
             ApiServiceContributor<T> contributor)
             where T : class
         {
             // Services have singleton lifetime by default, call Make... to change.
-            obj.TryAddSingleton(typeof(T), ChainedService<T>.DefaultFactory);
-            obj.AddInstance(contributor);
+            services.TryAddSingleton(typeof(T), ChainedService<T>.DefaultFactory);
+            services.AddInstance(contributor);
 
-            return obj;
+            return services;
         }
 
         private static MemberInfo FindInnerMemberAndInject<TService, TImplement>(

--- a/src/Microsoft.Restier.EntityFramework/DbApi.cs
+++ b/src/Microsoft.Restier.EntityFramework/DbApi.cs
@@ -63,14 +63,13 @@ namespace Microsoft.Restier.EntityFramework
             // Add core and conversion's services
             services = services.AddCoreServices(apiType)
                 .AddAttributeServices(apiType)
-                .AddConventionServices(apiType);
+                .AddConventionBasedServices(apiType);
 
             // Add EF related services
-            services.AddDbContextServices<T>();
+            services.AddEfProviderServices<T>();
 
             // This is used to add the publisher's services
-            // TODO, will think about a better way
-            ApiConfiguration.GetInternalServiceCallback(apiType)(services);
+            ApiConfiguration.GetPublisherServiceCallback(apiType)(services);
 
             return services;
         }

--- a/src/Microsoft.Restier.EntityFramework/Microsoft.Restier.EntityFramework.csproj
+++ b/src/Microsoft.Restier.EntityFramework/Microsoft.Restier.EntityFramework.csproj
@@ -76,6 +76,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="ServiceCollectionExtensions.cs" />
     <Compile Include="Submit\ChangeSetPreparer.cs" />
     <Compile Include="Submit\SubmitExecutor.cs" />
   </ItemGroup>

--- a/src/Microsoft.Restier.EntityFramework/Query/QueryExpressionFilter.cs
+++ b/src/Microsoft.Restier.EntityFramework/Query/QueryExpressionFilter.cs
@@ -13,10 +13,22 @@ namespace Microsoft.Restier.EntityFramework.Query
     /// </summary>
     internal class QueryExpressionFilter : IQueryExpressionFilter
     {
+        // It will be ConventionBasedEntitySetFilter
+        public IQueryExpressionFilter Inner { get; set; }
+
         /// <inheritdoc/>
         public Expression Filter(QueryExpressionContext context)
         {
             Ensure.NotNull(context, "context");
+
+            if (Inner != null)
+            {
+                var innerFilteredExpression = Inner.Filter(context);
+                if (innerFilteredExpression != null && innerFilteredExpression != context.VisitedNode)
+                {
+                    return innerFilteredExpression;
+                }
+            }
 
             // TODO GitHubIssue#330: EF QueryExecutor will throw exception if check whether collections is null added.
             // Error message likes "Cannot compare elements of type 'ICollection`1[[EntityType]]'.

--- a/src/Microsoft.Restier.EntityFramework/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Restier.EntityFramework/ServiceCollectionExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Restier.EntityFramework
     [CLSCompliant(false)]
     public static class ServiceCollectionExtensions
     {
-        public static IServiceCollection AddDbContextServices<TDbContext>(this IServiceCollection services)
+        public static IServiceCollection AddEfProviderServices<TDbContext>(this IServiceCollection services)
             where TDbContext : DbContext
         {
             services.TryAddScoped<TDbContext>();

--- a/src/Microsoft.Restier.EntityFramework/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Restier.EntityFramework/ServiceCollectionExtensions.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Data.Entity;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Restier.Core;
+using Microsoft.Restier.Core.Model;
+using Microsoft.Restier.Core.Query;
+using Microsoft.Restier.Core.Submit;
+using Microsoft.Restier.EntityFramework.Model;
+using Microsoft.Restier.EntityFramework.Query;
+using Microsoft.Restier.EntityFramework.Submit;
+
+namespace Microsoft.Restier.EntityFramework
+{
+    [CLSCompliant(false)]
+    public static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection AddDbContextServices<TDbContext>(this IServiceCollection services)
+            where TDbContext : DbContext
+        {
+            services.TryAddScoped<TDbContext>();
+            services.TryAddScoped(typeof(DbContext), sp => sp.GetService<TDbContext>());
+
+            services.AddScoped<TDbContext>(sp =>
+            {
+                var dbContext = Activator.CreateInstance<TDbContext>(); 
+#if EF7
+    // TODO GitHubIssue#58: Figure out the equivalent measurement to suppress proxy generation in EF7.
+#else
+                dbContext.Configuration.ProxyCreationEnabled = false;
+#endif
+                return dbContext;
+            });
+
+            return services
+                .CutoffPrevious<IModelBuilder>(ModelProducer.Instance)
+                .CutoffPrevious<IModelMapper>(new ModelMapper(typeof(TDbContext)))
+                .CutoffPrevious<IQueryExpressionSourcer, QueryExpressionSourcer>()
+                .ChainPrevious<IQueryExecutor, QueryExecutor>()
+                .ChainPrevious<IQueryExpressionFilter, QueryExpressionFilter>()
+                .CutoffPrevious<IChangeSetPreparer, ChangeSetPreparer>()
+                .CutoffPrevious<ISubmitExecutor>(SubmitExecutor.Instance);
+        }
+    }
+}

--- a/src/Microsoft.Restier.Security/DenyAttribute.cs
+++ b/src/Microsoft.Restier.Security/DenyAttribute.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Restier.Security
         /// The API type on which this attribute was placed.
         /// </param>
         [CLSCompliant(false)]
-        public override void ConfigureApi(IServiceCollection services, Type type)
+        public override void AddApiServices(IServiceCollection services, Type type)
         {
             var permission = ApiPermission.CreateDeny(
                 this.PermissionType,

--- a/src/Microsoft.Restier.Security/EnableRoleBasedSecurityAttribute.cs
+++ b/src/Microsoft.Restier.Security/EnableRoleBasedSecurityAttribute.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Restier.Security
         /// The API type on which this attribute was placed.
         /// </param>
         [CLSCompliant(false)]
-        public override void ConfigureApi(
+        public override void AddApiServices(
             IServiceCollection services,
             Type type)
         {

--- a/src/Microsoft.Restier.Security/GrantAttribute.cs
+++ b/src/Microsoft.Restier.Security/GrantAttribute.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Restier.Security
         /// The API type on which this attribute was placed.
         /// </param>
         [CLSCompliant(false)]
-        public override void ConfigureApi(IServiceCollection services, Type type)
+        public override void AddApiServices(IServiceCollection services, Type type)
         {
             var permission = ApiPermission.CreateGrant(
                 this.PermissionType,

--- a/src/Microsoft.Restier.WebApi/Filters/RestierExceptionFilterAttribute.cs
+++ b/src/Microsoft.Restier.WebApi/Filters/RestierExceptionFilterAttribute.cs
@@ -15,6 +15,7 @@ using System.Web.Http.Filters;
 using System.Web.Http.Results;
 using Microsoft.OData.Core;
 using Microsoft.Restier.Core.Submit;
+using Microsoft.Restier.WebApi.Query;
 
 namespace Microsoft.Restier.WebApi.Filters
 {

--- a/src/Microsoft.Restier.WebApi/Formatter/RestierFormattingAttribute.cs
+++ b/src/Microsoft.Restier.WebApi/Formatter/RestierFormattingAttribute.cs
@@ -9,7 +9,7 @@ using System.Web.OData.Formatter;
 using Microsoft.Restier.WebApi.Formatter.Deserialization;
 using Microsoft.Restier.WebApi.Formatter.Serialization;
 
-namespace Microsoft.Restier.WebApi
+namespace Microsoft.Restier.WebApi.Formatter
 {
     /// <summary>
     /// Specifies the serializer and deserializer provider for the API controller.

--- a/src/Microsoft.Restier.WebApi/Microsoft.Restier.WebApi.csproj
+++ b/src/Microsoft.Restier.WebApi/Microsoft.Restier.WebApi.csproj
@@ -57,6 +57,9 @@
       <Link>GlobalSuppressions.cs</Link>
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="..\Shared\EdmHelpers.cs">
+      <Link>Shared\EdmHelpers.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\Ensure.cs">
       <Link>Shared\Ensure.cs</Link>
     </Compile>
@@ -78,6 +81,8 @@
     <Compile Include="Batch\RestierBatchHandler.cs" />
     <Compile Include="Batch\RestierChangeSetProperty.cs" />
     <Compile Include="Batch\RestierChangeSetRequestItem.cs" />
+    <Compile Include="Model\ApiModelBuilder.cs" />
+    <Compile Include="Model\OperationModelBuilder.cs" />
     <Compile Include="Formatter\Deserialization\DefaultRestierDeserializerProvider.cs" />
     <Compile Include="Formatter\Deserialization\RestierEnumDeserializer.cs" />
     <Compile Include="Formatter\Serialization\DefaultRestierSerializerProvider.cs" />
@@ -88,12 +93,12 @@
     <Compile Include="Formatter\Serialization\RestierPrimitiveSerializer.cs" />
     <Compile Include="Formatter\Serialization\RestierEntityTypeSerializer.cs" />
     <Compile Include="Formatter\Serialization\RestierFeedSerializer.cs" />
-    <Compile Include="HttpConfigurationExtensions.cs" />
+    <Compile Include="Routing\HttpConfigurationExtensions.cs" />
     <Compile Include="HttpRequestMessageExtensions.cs" />
     <Compile Include="Query\RestierQueryExecutor.cs" />
-    <Compile Include="RestierQueryBuilder.cs" />
+    <Compile Include="Query\RestierQueryBuilder.cs" />
     <Compile Include="Extensions.cs" />
-    <Compile Include="RestierFormattingAttribute.cs" />
+    <Compile Include="Formatter\RestierFormattingAttribute.cs" />
     <Compile Include="Filters\RestierExceptionFilterAttribute.cs" />
     <Compile Include="RestierPayloadValueConverter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -121,6 +126,7 @@
       <DependentUpon>SharedResources.resx</DependentUpon>
     </Compile>
     <Compile Include="Query\RestierQueryExecutorOptions.cs" />
+    <Compile Include="ServiceCollectionExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Restier.Core\Microsoft.Restier.Core.csproj">

--- a/src/Microsoft.Restier.WebApi/Microsoft.Restier.WebApi.csproj
+++ b/src/Microsoft.Restier.WebApi/Microsoft.Restier.WebApi.csproj
@@ -57,9 +57,6 @@
       <Link>GlobalSuppressions.cs</Link>
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
-    <Compile Include="..\Shared\EdmHelpers.cs">
-      <Link>Shared\EdmHelpers.cs</Link>
-    </Compile>
     <Compile Include="..\Shared\Ensure.cs">
       <Link>Shared\Ensure.cs</Link>
     </Compile>
@@ -81,8 +78,8 @@
     <Compile Include="Batch\RestierBatchHandler.cs" />
     <Compile Include="Batch\RestierChangeSetProperty.cs" />
     <Compile Include="Batch\RestierChangeSetRequestItem.cs" />
-    <Compile Include="Model\ApiModelBuilder.cs" />
-    <Compile Include="Model\OperationModelBuilder.cs" />
+    <Compile Include="Model\RestierModelExtender.cs" />
+    <Compile Include="Model\RestierOperationModelBuilder.cs" />
     <Compile Include="Formatter\Deserialization\DefaultRestierDeserializerProvider.cs" />
     <Compile Include="Formatter\Deserialization\RestierEnumDeserializer.cs" />
     <Compile Include="Formatter\Serialization\DefaultRestierSerializerProvider.cs" />
@@ -127,6 +124,7 @@
     </Compile>
     <Compile Include="Query\RestierQueryExecutorOptions.cs" />
     <Compile Include="ServiceCollectionExtensions.cs" />
+    <Compile Include="Model\EdmHelpers.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Restier.Core\Microsoft.Restier.Core.csproj">

--- a/src/Microsoft.Restier.WebApi/Model/EdmHelpers.cs
+++ b/src/Microsoft.Restier.WebApi/Model/EdmHelpers.cs
@@ -4,10 +4,11 @@
 using System;
 using System.Globalization;
 using System.Linq;
+using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Library;
 using Microsoft.Restier.WebApi.Properties;
 
-namespace Microsoft.OData.Edm
+namespace Microsoft.Restier.WebApi.Model
 {
     internal static class EdmHelpers
     {

--- a/src/Microsoft.Restier.WebApi/Model/OperationModelBuilder.cs
+++ b/src/Microsoft.Restier.WebApi/Model/OperationModelBuilder.cs
@@ -11,17 +11,18 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Library;
 using Microsoft.OData.Edm.Library.Expressions;
+using Microsoft.Restier.Core;
 using Microsoft.Restier.Core.Model;
 
-namespace Microsoft.Restier.Core.Conventions
+namespace Microsoft.Restier.WebApi.Model
 {
-    internal class ConventionBasedOperationProvider : IModelBuilder
+    internal class OperationModelBuilder : IModelBuilder
     {
         private readonly Type targetType;
         private readonly ICollection<ActionMethodInfo> actionInfos = new List<ActionMethodInfo>();
         private readonly ICollection<FunctionMethodInfo> functionInfos = new List<FunctionMethodInfo>();
 
-        private ConventionBasedOperationProvider(Type targetType)
+        private OperationModelBuilder(Type targetType)
         {
             this.targetType = targetType;
         }
@@ -30,7 +31,7 @@ namespace Microsoft.Restier.Core.Conventions
 
         public static void ApplyTo(IServiceCollection services, Type targetType)
         {
-            services.ChainPrevious<IModelBuilder>(next => new ConventionBasedOperationProvider(targetType)
+            services.ChainPrevious<IModelBuilder>(next => new OperationModelBuilder(targetType)
             {
                 InnerHandler = next,
             });

--- a/src/Microsoft.Restier.WebApi/Model/RestierModelExtender.cs
+++ b/src/Microsoft.Restier.WebApi/Model/RestierModelExtender.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Restier.WebApi.Model
     /// A convention-based API model builder that extends a model, maps between
     /// the model space and the object space, and expands a query expression.
     /// </summary>
-    internal class ApiModelBuilder
+    internal class RestierModelExtender
     {
         private readonly Type targetType;
         private readonly ICollection<PropertyInfo> publicProperties = new List<PropertyInfo>();
@@ -35,7 +35,7 @@ namespace Microsoft.Restier.WebApi.Model
         private readonly IDictionary<IEdmEntityType, IEdmSingleton[]> singletonCache =
             new Dictionary<IEdmEntityType, IEdmSingleton[]>();
 
-        private ApiModelBuilder(Type targetType)
+        private RestierModelExtender(Type targetType)
         {
             this.targetType = targetType;
         }
@@ -49,7 +49,7 @@ namespace Microsoft.Restier.WebApi.Model
 
             // The model builder must maintain a singleton life time, for holding states and being injected into
             // some other services.
-            services.AddInstance(new ApiModelBuilder(targetType));
+            services.AddInstance(new RestierModelExtender(targetType));
 
             services.ChainPrevious<IModelBuilder, ModelBuilder>();
             services.ChainPrevious<IModelMapper, ModelMapper>();
@@ -300,14 +300,14 @@ namespace Microsoft.Restier.WebApi.Model
 
         internal class ModelBuilder : IModelBuilder
         {
-            public ModelBuilder(ApiModelBuilder modelCache)
+            public ModelBuilder(RestierModelExtender modelCache)
             {
                 ModelCache = modelCache;
             }
 
             public IModelBuilder InnerModelBuilder { get; private set; }
 
-            private ApiModelBuilder ModelCache { get; set; }
+            private RestierModelExtender ModelCache { get; set; }
 
             /// <inheritdoc/>
             public async Task<IEdmModel> GetModelAsync(InvocationContext context, CancellationToken cancellationToken)
@@ -351,12 +351,12 @@ namespace Microsoft.Restier.WebApi.Model
 
         internal class ModelMapper : IModelMapper
         {
-            public ModelMapper(ApiModelBuilder modelCache)
+            public ModelMapper(RestierModelExtender modelCache)
             {
                 ModelCache = modelCache;
             }
 
-            public ApiModelBuilder ModelCache { get; set; }
+            public RestierModelExtender ModelCache { get; set; }
 
             private IModelMapper InnerModelMapper { get; set; }
 
@@ -411,7 +411,7 @@ namespace Microsoft.Restier.WebApi.Model
 
         internal class QueryExpressionExpander : IQueryExpressionExpander
         {
-            public QueryExpressionExpander(ApiModelBuilder modelCache)
+            public QueryExpressionExpander(RestierModelExtender modelCache)
             {
                 ModelCache = modelCache;
             }
@@ -419,7 +419,7 @@ namespace Microsoft.Restier.WebApi.Model
             /// <inheritdoc/>
             public IQueryExpressionExpander InnerHandler { get; set; }
 
-            private ApiModelBuilder ModelCache { get; set; }
+            private RestierModelExtender ModelCache { get; set; }
 
             /// <inheritdoc/>
             public Expression Expand(QueryExpressionContext context)
@@ -460,14 +460,14 @@ namespace Microsoft.Restier.WebApi.Model
 
         internal class QueryExpressionSourcer : IQueryExpressionSourcer
         {
-            public QueryExpressionSourcer(ApiModelBuilder modelCache)
+            public QueryExpressionSourcer(RestierModelExtender modelCache)
             {
                 ModelCache = modelCache;
             }
 
             public IQueryExpressionSourcer InnerHandler { get; set; }
 
-            private ApiModelBuilder ModelCache { get; set; }
+            private RestierModelExtender ModelCache { get; set; }
 
             /// <inheritdoc/>
             public Expression Source(QueryExpressionContext context, bool embedded)

--- a/src/Microsoft.Restier.WebApi/Model/RestierOperationModelBuilder.cs
+++ b/src/Microsoft.Restier.WebApi/Model/RestierOperationModelBuilder.cs
@@ -16,13 +16,13 @@ using Microsoft.Restier.Core.Model;
 
 namespace Microsoft.Restier.WebApi.Model
 {
-    internal class OperationModelBuilder : IModelBuilder
+    internal class RestierOperationModelBuilder : IModelBuilder
     {
         private readonly Type targetType;
         private readonly ICollection<ActionMethodInfo> actionInfos = new List<ActionMethodInfo>();
         private readonly ICollection<FunctionMethodInfo> functionInfos = new List<FunctionMethodInfo>();
 
-        private OperationModelBuilder(Type targetType)
+        private RestierOperationModelBuilder(Type targetType)
         {
             this.targetType = targetType;
         }
@@ -31,7 +31,7 @@ namespace Microsoft.Restier.WebApi.Model
 
         public static void ApplyTo(IServiceCollection services, Type targetType)
         {
-            services.ChainPrevious<IModelBuilder>(next => new OperationModelBuilder(targetType)
+            services.ChainPrevious<IModelBuilder>(next => new RestierOperationModelBuilder(targetType)
             {
                 InnerHandler = next,
             });

--- a/src/Microsoft.Restier.WebApi/Properties/Resources.Designer.cs
+++ b/src/Microsoft.Restier.WebApi/Properties/Resources.Designer.cs
@@ -178,6 +178,15 @@ namespace Microsoft.Restier.WebApi.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Not supported type: {0}..
+        /// </summary>
+        internal static string NotSupportedType {
+            get {
+                return ResourceManager.GetString("NotSupportedType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Path segment not supported: {0}.
         /// </summary>
         internal static string PathSegmentNotSupported {

--- a/src/Microsoft.Restier.WebApi/Properties/Resources.resx
+++ b/src/Microsoft.Restier.WebApi/Properties/Resources.resx
@@ -156,6 +156,9 @@
   <data name="MultiKeyValuesExpected" xml:space="preserve">
     <value>Only one key was specified, when multiple were expected.</value>
   </data>
+  <data name="NotSupportedType" xml:space="preserve">
+    <value>Not supported type: {0}.</value>
+  </data>
   <data name="PathSegmentNotSupported" xml:space="preserve">
     <value>Path segment not supported: {0}</value>
   </data>

--- a/src/Microsoft.Restier.WebApi/Query/RestierQueryBuilder.cs
+++ b/src/Microsoft.Restier.WebApi/Query/RestierQueryBuilder.cs
@@ -13,7 +13,7 @@ using Microsoft.OData.Edm;
 using Microsoft.Restier.Core;
 using Microsoft.Restier.WebApi.Properties;
 
-namespace Microsoft.Restier.WebApi
+namespace Microsoft.Restier.WebApi.Query
 {
     internal class RestierQueryBuilder
     {

--- a/src/Microsoft.Restier.WebApi/RestierController.cs
+++ b/src/Microsoft.Restier.WebApi/RestierController.cs
@@ -24,6 +24,7 @@ using Microsoft.Restier.Core.Query;
 using Microsoft.Restier.Core.Submit;
 using Microsoft.Restier.WebApi.Batch;
 using Microsoft.Restier.WebApi.Filters;
+using Microsoft.Restier.WebApi.Formatter;
 using Microsoft.Restier.WebApi.Properties;
 using Microsoft.Restier.WebApi.Query;
 using Microsoft.Restier.WebApi.Results;

--- a/src/Microsoft.Restier.WebApi/Routing/HttpConfigurationExtensions.cs
+++ b/src/Microsoft.Restier.WebApi/Routing/HttpConfigurationExtensions.cs
@@ -9,16 +9,12 @@ using System.Web.Http;
 using System.Web.OData.Extensions;
 using System.Web.OData.Routing;
 using System.Web.OData.Routing.Conventions;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OData.Core;
 using Microsoft.OData.Edm;
 using Microsoft.Restier.Core;
-using Microsoft.Restier.Core.Query;
 using Microsoft.Restier.WebApi.Batch;
-using Microsoft.Restier.WebApi.Query;
-using Microsoft.Restier.WebApi.Routing;
 
-namespace Microsoft.Restier.WebApi
+namespace Microsoft.Restier.WebApi.Routing
 {
     /// <summary>
     /// Offers a collection of extension methods to <see cref="HttpConfiguration"/>.
@@ -47,11 +43,10 @@ namespace Microsoft.Restier.WebApi
         {
             Ensure.NotNull(apiFactory, "apiFactory");
 
-            // ApiBase.ConfigureApi is called before this method is called.
-            ApiConfiguration.Configure<TApi>(services =>
+            // This will be added a service add callback which is added in ApiBase.ConfigureApi method.
+            ApiConfiguration.AddInternalServices<TApi>(services =>
             {
-                services.AddScoped<RestierQueryExecutorOptions>()
-                    .ChainPrevious<IQueryExecutor, RestierQueryExecutor>();
+                services.AddWebApiServices<TApi>();
             });
             using (var api = apiFactory())
             {

--- a/src/Microsoft.Restier.WebApi/Routing/HttpConfigurationExtensions.cs
+++ b/src/Microsoft.Restier.WebApi/Routing/HttpConfigurationExtensions.cs
@@ -43,8 +43,9 @@ namespace Microsoft.Restier.WebApi.Routing
         {
             Ensure.NotNull(apiFactory, "apiFactory");
 
-            // This will be added a service add callback which is added in ApiBase.ConfigureApi method.
-            ApiConfiguration.AddInternalServices<TApi>(services =>
+            // This will be added a service to callback stored in ApiConfiguration
+            // Callback is called by ApiBase.AddApiServices method to add real services.
+            ApiConfiguration.AddPublisherServices<TApi>(services =>
             {
                 services.AddWebApiServices<TApi>();
             });

--- a/src/Microsoft.Restier.WebApi/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Restier.WebApi/ServiceCollectionExtensions.cs
@@ -7,13 +7,12 @@ using Microsoft.Restier.WebApi.Query;
 
 namespace Microsoft.Restier.WebApi
 {
-    [CLSCompliant(false)]
-    public static class ServiceCollectionExtensions
+    internal static class ServiceCollectionExtensions
     {
         public static IServiceCollection AddWebApiServices<T>(this IServiceCollection services)
         {
-            ApiModelBuilder.ApplyTo(services, typeof(T));
-            OperationModelBuilder.ApplyTo(services, typeof(T));
+            RestierModelExtender.ApplyTo(services, typeof(T));
+            RestierOperationModelBuilder.ApplyTo(services, typeof(T));
             return
                 services.AddScoped<RestierQueryExecutorOptions>()
                     .ChainPrevious<IQueryExecutor, RestierQueryExecutor>();

--- a/src/Microsoft.Restier.WebApi/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Restier.WebApi/ServiceCollectionExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Restier.Core;
+using Microsoft.Restier.Core.Query;
+using Microsoft.Restier.WebApi.Model;
+using Microsoft.Restier.WebApi.Query;
+
+namespace Microsoft.Restier.WebApi
+{
+    [CLSCompliant(false)]
+    public static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection AddWebApiServices<T>(this IServiceCollection services)
+        {
+            ApiModelBuilder.ApplyTo(services, typeof(T));
+            OperationModelBuilder.ApplyTo(services, typeof(T));
+            return
+                services.AddScoped<RestierQueryExecutorOptions>()
+                    .ChainPrevious<IQueryExecutor, RestierQueryExecutor>();
+        }
+    }
+}

--- a/src/Shared/EdmHelpers.cs
+++ b/src/Shared/EdmHelpers.cs
@@ -5,7 +5,7 @@ using System;
 using System.Globalization;
 using System.Linq;
 using Microsoft.OData.Edm.Library;
-using Microsoft.Restier.Core.Properties;
+using Microsoft.Restier.WebApi.Properties;
 
 namespace Microsoft.OData.Edm
 {

--- a/test/Microsoft.Restier.Core.Tests/Microsoft.Restier.Core.Tests.csproj
+++ b/test/Microsoft.Restier.Core.Tests/Microsoft.Restier.Core.Tests.csproj
@@ -67,7 +67,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ServiceConfiguration.Tests.cs" />
-    <Compile Include="Model\ConventionBasedApiModelBuilder.Tests.cs" />
     <Compile Include="Model\DefaultModelHandler.Tests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ApiConfiguration.Tests.cs" />

--- a/test/Microsoft.Restier.TestCommon/PublicApi.bsl
+++ b/test/Microsoft.Restier.TestCommon/PublicApi.bsl
@@ -129,6 +129,11 @@ public sealed class Microsoft.Restier.Core.ApiConfigurationExtensions {
 	[
 	ExtensionAttribute(),
 	]
+	public static bool IsPropertyIgnored (Microsoft.Restier.Core.ApiConfiguration configuration, string propertyName)
+
+	[
+	ExtensionAttribute(),
+	]
 	public static void SetProperty (Microsoft.Restier.Core.ApiConfiguration configuration, string name, object value)
 }
 
@@ -243,7 +248,22 @@ public sealed class Microsoft.Restier.Core.ServiceCollectionExtensions {
 	[
 	ExtensionAttribute(),
 	]
+	public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddAttributeServices (Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Type apiType)
+
+	[
+	ExtensionAttribute(),
+	]
 	public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddContributor (Microsoft.Extensions.DependencyInjection.IServiceCollection obj, ApiServiceContributor`1 contributor)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddConventionServices (Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Type apiType)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddCoreServices (Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Type apiType)
 
 	[
 	ExtensionAttribute(),
@@ -314,7 +334,12 @@ public class Microsoft.Restier.Core.ApiConfiguration {
 	[
 	CLSCompliantAttribute(),
 	]
-	public static void Configure (System.Action`1[[Microsoft.Extensions.DependencyInjection.IServiceCollection]] configurationCallback)
+	public static void AddInternalServices (System.Action`1[[Microsoft.Extensions.DependencyInjection.IServiceCollection]] configurationCallback)
+
+	[
+	CLSCompliantAttribute(),
+	]
+	public static System.Action`1[[Microsoft.Extensions.DependencyInjection.IServiceCollection]] GetInternalServiceCallback (System.Type apiType)
 }
 
 public class Microsoft.Restier.Core.ApiContext {
@@ -338,6 +363,17 @@ public sealed class Microsoft.Restier.Core.ApiServiceContributor`1 : System.Mult
 	public virtual T Invoke (System.IServiceProvider serviceProvider, Func`1 next)
 }
 
+[
+CLSCompliantAttribute(),
+ExtensionAttribute(),
+]
+public sealed class Microsoft.Restier.EntityFramework.ServiceCollectionExtensions {
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddDbContextServices (Microsoft.Extensions.DependencyInjection.IServiceCollection services)
+}
+
 public class Microsoft.Restier.EntityFramework.DbApi`1 : Microsoft.Restier.Core.ApiBase, IDisposable {
 	public DbApi`1 ()
 
@@ -347,29 +383,22 @@ public class Microsoft.Restier.EntityFramework.DbApi`1 : Microsoft.Restier.Core.
 	CLSCompliantAttribute(),
 	]
 	protected virtual Microsoft.Extensions.DependencyInjection.IServiceCollection ConfigureApi (Microsoft.Extensions.DependencyInjection.IServiceCollection services)
-
-	protected virtual T CreateDbContext (System.IServiceProvider serviceProvider)
 }
 
 [
-EditorBrowsableAttribute(),
+CLSCompliantAttribute(),
 ExtensionAttribute(),
 ]
-public sealed class Microsoft.Restier.WebApi.HttpConfigurationExtensions {
+public sealed class Microsoft.Restier.WebApi.ServiceCollectionExtensions {
 	[
 	ExtensionAttribute(),
 	]
-	public static System.Threading.Tasks.Task`1[[System.Web.OData.Routing.ODataRoute]] MapRestierRoute (System.Web.Http.HttpConfiguration config, string routeName, string routePrefix, params Microsoft.Restier.WebApi.Batch.RestierBatchHandler batchHandler)
-
-	[
-	ExtensionAttribute(),
-	]
-	public static System.Threading.Tasks.Task`1[[System.Web.OData.Routing.ODataRoute]] MapRestierRoute (System.Web.Http.HttpConfiguration config, string routeName, string routePrefix, System.Func`1[[Microsoft.Restier.Core.ApiBase]] apiFactory, params Microsoft.Restier.WebApi.Batch.RestierBatchHandler batchHandler)
+	public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddWebApiServices (Microsoft.Extensions.DependencyInjection.IServiceCollection services)
 }
 
 [
-RestierFormattingAttribute(),
 RestierExceptionFilterAttribute(),
+RestierFormattingAttribute(),
 ]
 public class Microsoft.Restier.WebApi.RestierController : System.Web.OData.ODataController, IDisposable, IHttpController {
 	public RestierController ()
@@ -702,6 +731,22 @@ public class Microsoft.Restier.WebApi.Batch.RestierChangeSetRequestItem : System
 	AsyncStateMachineAttribute(),
 	]
 	public virtual System.Threading.Tasks.Task`1[[System.Web.OData.Batch.ODataBatchResponseItem]] SendRequestAsync (System.Net.Http.HttpMessageInvoker invoker, System.Threading.CancellationToken cancellationToken)
+}
+
+[
+EditorBrowsableAttribute(),
+ExtensionAttribute(),
+]
+public sealed class Microsoft.Restier.WebApi.Routing.HttpConfigurationExtensions {
+	[
+	ExtensionAttribute(),
+	]
+	public static System.Threading.Tasks.Task`1[[System.Web.OData.Routing.ODataRoute]] MapRestierRoute (System.Web.Http.HttpConfiguration config, string routeName, string routePrefix, params Microsoft.Restier.WebApi.Batch.RestierBatchHandler batchHandler)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static System.Threading.Tasks.Task`1[[System.Web.OData.Routing.ODataRoute]] MapRestierRoute (System.Web.Http.HttpConfiguration config, string routeName, string routePrefix, System.Func`1[[Microsoft.Restier.Core.ApiBase]] apiFactory, params Microsoft.Restier.WebApi.Batch.RestierBatchHandler batchHandler)
 }
 
 public class Microsoft.Restier.WebApi.Formatter.Serialization.DefaultRestierSerializerProvider : System.Web.OData.Formatter.Serialization.DefaultODataSerializerProvider {

--- a/test/Microsoft.Restier.TestCommon/PublicApi.bsl
+++ b/test/Microsoft.Restier.TestCommon/PublicApi.bsl
@@ -31,17 +31,9 @@ public abstract class Microsoft.Restier.Core.ApiConfiguratorAttribute : System.A
 	[
 	CLSCompliantAttribute(),
 	]
-	public static void ApplyApiServices (System.Type type, Microsoft.Extensions.DependencyInjection.IServiceCollection services)
+	public virtual void AddApiServices (Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Type type)
 
-	public static void ApplyConfiguration (System.Type type, Microsoft.Restier.Core.ApiConfiguration configuration)
-	public static void ApplyDisposal (System.Type type, object instance, Microsoft.Restier.Core.ApiContext context)
-	public static void ApplyInitialization (System.Type type, object instance, Microsoft.Restier.Core.ApiContext context)
 	public virtual void Configure (Microsoft.Restier.Core.ApiConfiguration configuration, System.Type type)
-	[
-	CLSCompliantAttribute(),
-	]
-	public virtual void ConfigureApi (Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Type type)
-
 	public virtual void Dispose (Microsoft.Restier.Core.ApiContext context, System.Type type, object instance)
 	public virtual void Initialize (Microsoft.Restier.Core.ApiContext context, System.Type type, object instance)
 }
@@ -253,12 +245,12 @@ public sealed class Microsoft.Restier.Core.ServiceCollectionExtensions {
 	[
 	ExtensionAttribute(),
 	]
-	public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddContributor (Microsoft.Extensions.DependencyInjection.IServiceCollection obj, ApiServiceContributor`1 contributor)
+	public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddContributor (Microsoft.Extensions.DependencyInjection.IServiceCollection services, ApiServiceContributor`1 contributor)
 
 	[
 	ExtensionAttribute(),
 	]
-	public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddConventionServices (Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Type apiType)
+	public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddConventionBasedServices (Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Type apiType)
 
 	[
 	ExtensionAttribute(),
@@ -268,62 +260,62 @@ public sealed class Microsoft.Restier.Core.ServiceCollectionExtensions {
 	[
 	ExtensionAttribute(),
 	]
-	public static Microsoft.Restier.Core.ApiConfiguration BuildApiConfiguration (Microsoft.Extensions.DependencyInjection.IServiceCollection obj)
+	public static Microsoft.Restier.Core.ApiConfiguration BuildApiConfiguration (Microsoft.Extensions.DependencyInjection.IServiceCollection services)
 
 	[
 	ExtensionAttribute(),
 	]
-	public static Microsoft.Restier.Core.ApiConfiguration BuildApiConfiguration (Microsoft.Extensions.DependencyInjection.IServiceCollection obj, System.Func`2[[Microsoft.Extensions.DependencyInjection.IServiceCollection],[System.IServiceProvider]] serviceProviderFactory)
+	public static Microsoft.Restier.Core.ApiConfiguration BuildApiConfiguration (Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func`2[[Microsoft.Extensions.DependencyInjection.IServiceCollection],[System.IServiceProvider]] serviceProviderFactory)
 
 	[
 	ExtensionAttribute(),
 	]
-	public static T BuildApiServiceChain (System.IServiceProvider obj)
+	public static T BuildApiServiceChain (System.IServiceProvider services)
 
 	[
 	ExtensionAttribute(),
 	]
-	public static Microsoft.Extensions.DependencyInjection.IServiceCollection ChainPrevious (Microsoft.Extensions.DependencyInjection.IServiceCollection obj)
+	public static Microsoft.Extensions.DependencyInjection.IServiceCollection ChainPrevious (Microsoft.Extensions.DependencyInjection.IServiceCollection services)
 
 	[
 	ExtensionAttribute(),
 	]
-	public static Microsoft.Extensions.DependencyInjection.IServiceCollection ChainPrevious (Microsoft.Extensions.DependencyInjection.IServiceCollection obj, Func`2 factory)
+	public static Microsoft.Extensions.DependencyInjection.IServiceCollection ChainPrevious (Microsoft.Extensions.DependencyInjection.IServiceCollection services, Func`2 factory)
 
 	[
 	ExtensionAttribute(),
 	]
-	public static Microsoft.Extensions.DependencyInjection.IServiceCollection ChainPrevious (Microsoft.Extensions.DependencyInjection.IServiceCollection obj, Func`3 factory)
+	public static Microsoft.Extensions.DependencyInjection.IServiceCollection ChainPrevious (Microsoft.Extensions.DependencyInjection.IServiceCollection services, Func`3 factory)
 
 	[
 	ExtensionAttribute(),
 	]
-	public static Microsoft.Extensions.DependencyInjection.IServiceCollection CutoffPrevious (Microsoft.Extensions.DependencyInjection.IServiceCollection obj)
+	public static Microsoft.Extensions.DependencyInjection.IServiceCollection CutoffPrevious (Microsoft.Extensions.DependencyInjection.IServiceCollection services)
 
 	[
 	ExtensionAttribute(),
 	]
-	public static Microsoft.Extensions.DependencyInjection.IServiceCollection CutoffPrevious (Microsoft.Extensions.DependencyInjection.IServiceCollection obj, T handler)
+	public static Microsoft.Extensions.DependencyInjection.IServiceCollection CutoffPrevious (Microsoft.Extensions.DependencyInjection.IServiceCollection services, T handler)
 
 	[
 	ExtensionAttribute(),
 	]
-	public static bool HasService (Microsoft.Extensions.DependencyInjection.IServiceCollection obj)
+	public static bool HasService (Microsoft.Extensions.DependencyInjection.IServiceCollection services)
 
 	[
 	ExtensionAttribute(),
 	]
-	public static Microsoft.Extensions.DependencyInjection.IServiceCollection MakeScoped (Microsoft.Extensions.DependencyInjection.IServiceCollection obj)
+	public static Microsoft.Extensions.DependencyInjection.IServiceCollection MakeScoped (Microsoft.Extensions.DependencyInjection.IServiceCollection services)
 
 	[
 	ExtensionAttribute(),
 	]
-	public static Microsoft.Extensions.DependencyInjection.IServiceCollection MakeSingleton (Microsoft.Extensions.DependencyInjection.IServiceCollection obj)
+	public static Microsoft.Extensions.DependencyInjection.IServiceCollection MakeSingleton (Microsoft.Extensions.DependencyInjection.IServiceCollection services)
 
 	[
 	ExtensionAttribute(),
 	]
-	public static Microsoft.Extensions.DependencyInjection.IServiceCollection MakeTransient (Microsoft.Extensions.DependencyInjection.IServiceCollection obj)
+	public static Microsoft.Extensions.DependencyInjection.IServiceCollection MakeTransient (Microsoft.Extensions.DependencyInjection.IServiceCollection services)
 }
 
 public class Microsoft.Restier.Core.ApiConfiguration {
@@ -334,12 +326,12 @@ public class Microsoft.Restier.Core.ApiConfiguration {
 	[
 	CLSCompliantAttribute(),
 	]
-	public static void AddInternalServices (System.Action`1[[Microsoft.Extensions.DependencyInjection.IServiceCollection]] configurationCallback)
+	public static void AddPublisherServices (System.Action`1[[Microsoft.Extensions.DependencyInjection.IServiceCollection]] configurationCallback)
 
 	[
 	CLSCompliantAttribute(),
 	]
-	public static System.Action`1[[Microsoft.Extensions.DependencyInjection.IServiceCollection]] GetInternalServiceCallback (System.Type apiType)
+	public static System.Action`1[[Microsoft.Extensions.DependencyInjection.IServiceCollection]] GetPublisherServiceCallback (System.Type apiType)
 }
 
 public class Microsoft.Restier.Core.ApiContext {
@@ -371,7 +363,7 @@ public sealed class Microsoft.Restier.EntityFramework.ServiceCollectionExtension
 	[
 	ExtensionAttribute(),
 	]
-	public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddDbContextServices (Microsoft.Extensions.DependencyInjection.IServiceCollection services)
+	public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddEfProviderServices (Microsoft.Extensions.DependencyInjection.IServiceCollection services)
 }
 
 public class Microsoft.Restier.EntityFramework.DbApi`1 : Microsoft.Restier.Core.ApiBase, IDisposable {
@@ -383,17 +375,6 @@ public class Microsoft.Restier.EntityFramework.DbApi`1 : Microsoft.Restier.Core.
 	CLSCompliantAttribute(),
 	]
 	protected virtual Microsoft.Extensions.DependencyInjection.IServiceCollection ConfigureApi (Microsoft.Extensions.DependencyInjection.IServiceCollection services)
-}
-
-[
-CLSCompliantAttribute(),
-ExtensionAttribute(),
-]
-public sealed class Microsoft.Restier.WebApi.ServiceCollectionExtensions {
-	[
-	ExtensionAttribute(),
-	]
-	public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddWebApiServices (Microsoft.Extensions.DependencyInjection.IServiceCollection services)
 }
 
 [

--- a/test/Microsoft.Restier.WebApi.Test/ExceptionHandlerTests.cs
+++ b/test/Microsoft.Restier.WebApi.Test/ExceptionHandlerTests.cs
@@ -7,6 +7,7 @@ using System.Web.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Restier.Core;
 using Microsoft.Restier.Core.Query;
+using Microsoft.Restier.WebApi.Routing;
 using Xunit;
 
 namespace Microsoft.Restier.WebApi.Test

--- a/test/Microsoft.Restier.WebApi.Test/FallbackTests.cs
+++ b/test/Microsoft.Restier.WebApi.Test/FallbackTests.cs
@@ -17,6 +17,7 @@ using Microsoft.OData.Edm.Library;
 using Microsoft.Restier.Core;
 using Microsoft.Restier.Core.Model;
 using Microsoft.Restier.Core.Query;
+using Microsoft.Restier.WebApi.Routing;
 using Xunit;
 
 namespace Microsoft.Restier.WebApi.Test
@@ -97,10 +98,10 @@ namespace Microsoft.Restier.WebApi.Test
     {
         protected override IServiceCollection ConfigureApi(IServiceCollection services)
         {
-            services = base.ConfigureApi(services);
             services.CutoffPrevious<IModelBuilder>(new TestModelProducer(FallbackModel.Model));
             services.CutoffPrevious<IModelMapper>(new FallbackModelMapper());
             services.CutoffPrevious<IQueryExpressionSourcer>(new FallbackQueryExpressionSourcer());
+            services = base.ConfigureApi(services);
             return services;
         }
 

--- a/test/Microsoft.Restier.WebApi.Test/Microsoft.Restier.WebApi.Test.csproj
+++ b/test/Microsoft.Restier.WebApi.Test/Microsoft.Restier.WebApi.Test.csproj
@@ -95,7 +95,7 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
-    <Compile Include="Model\ApiModelBuilder.Tests.cs" />
+    <Compile Include="Model\RestierModelExtender.Tests.cs" />
     <Compile Include="FallbackTests.cs" />
     <Compile Include="ExceptionHandlerTests.cs" />
     <Compile Include="RestierQueryBuilderTests.cs" />

--- a/test/Microsoft.Restier.WebApi.Test/Microsoft.Restier.WebApi.Test.csproj
+++ b/test/Microsoft.Restier.WebApi.Test/Microsoft.Restier.WebApi.Test.csproj
@@ -95,6 +95,7 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
+    <Compile Include="Model\ApiModelBuilder.Tests.cs" />
     <Compile Include="FallbackTests.cs" />
     <Compile Include="ExceptionHandlerTests.cs" />
     <Compile Include="RestierQueryBuilderTests.cs" />

--- a/test/Microsoft.Restier.WebApi.Test/Model/RestierModelExtender.Tests.cs
+++ b/test/Microsoft.Restier.WebApi.Test/Model/RestierModelExtender.Tests.cs
@@ -3,16 +3,18 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Web.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Library;
 using Microsoft.Restier.Core;
 using Microsoft.Restier.Core.Model;
+using Microsoft.Restier.WebApi.Routing;
 using Xunit;
 
 namespace Microsoft.Restier.WebApi.Test.Model
 {
-    public class ApiModelBuilderTests
+    public class RestierModelExtenderTests
     {
         [Fact]
         public async Task ApiModelBuilderShouldProduceEmptyModelForEmptyApi()
@@ -132,10 +134,9 @@ namespace Microsoft.Restier.WebApi.Test.Model
         private async Task<IEdmModel> GetModelAsync<T>() where T : BaseApi, new()
         {
             var api = (BaseApi)Activator.CreateInstance<T>();
-            ApiConfiguration.AddInternalServices<T>(services =>
-            {
-                services.AddWebApiServices<T>();
-            });
+            HttpConfiguration config = new HttpConfiguration();
+            await config.MapRestierRoute<T>(
+                    "test", "api/test",null);
             return await api.Context.GetModelAsync();
         }
     }

--- a/test/Microsoft.Restier.WebApi.Test/RestierControllerTests.cs
+++ b/test/Microsoft.Restier.WebApi.Test/RestierControllerTests.cs
@@ -7,6 +7,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using System.Web.Http;
+using Microsoft.Restier.WebApi.Routing;
 using Xunit;
 
 namespace Microsoft.Restier.WebApi.Test

--- a/test/Microsoft.Restier.WebApi.Test/RestierQueryBuilderTests.cs
+++ b/test/Microsoft.Restier.WebApi.Test/RestierQueryBuilderTests.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using System.Web.Http;
+using Microsoft.Restier.WebApi.Routing;
 using Xunit;
 
 namespace Microsoft.Restier.WebApi.Test

--- a/test/ODataEndToEndTests/Microsoft.Restier.Samples.Northwind.Tests/OperationTests.cs
+++ b/test/ODataEndToEndTests/Microsoft.Restier.Samples.Northwind.Tests/OperationTests.cs
@@ -16,13 +16,6 @@ namespace Microsoft.Restier.Samples.Northwind.Tests
 {
     public class OperationTests : TestBase
     {
-        private NorthwindApi api = new NorthwindApi();
-
-        private IQueryable<Product> ProductsQuery
-        {
-            get { return this.api.Source<Product>("Products"); }
-        }
-
         [Fact]
         public async Task FunctionCallWithFullName()
         {
@@ -68,11 +61,9 @@ namespace Microsoft.Restier.Samples.Northwind.Tests
 
         private async Task ActionCall(bool isqualified, Action<HttpConfiguration, HttpServer> registerOData)
         {
-            var query = this.api.Source<Product>("Products").OrderBy(p => p.ProductID).Take(1);
-            QueryResult result = await this.api.QueryAsync(
-                   new QueryRequest(query));
-
-            var product = result.Results.OfType<Product>().First();
+            NorthwindContext ctx = GetDbContext();
+            Product product = ctx.Products.First();
+            
             var productID = product.ProductID;
             var price = product.UnitPrice;
 
@@ -97,6 +88,11 @@ namespace Microsoft.Restier.Samples.Northwind.Tests
             Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
             var responseString = await BaselineHelpers.GetFormattedContent(getResponse);
             Assert.True(responseString.Contains(string.Format(@"""UnitPrice"":{0}", price + 2)));
+        }
+
+        private static NorthwindContext GetDbContext()
+        {
+            return new NorthwindContext();
         }
     }
 }

--- a/test/ODataEndToEndTests/Microsoft.Restier.Samples.Northwind.Tests/QueryTests.cs
+++ b/test/ODataEndToEndTests/Microsoft.Restier.Samples.Northwind.Tests/QueryTests.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using System.Threading.Tasks;
+using System.Web.Http;
 using Microsoft.Restier.Core;
 using Microsoft.Restier.Core.Query;
 using Microsoft.Restier.Samples.Northwind.Models;
@@ -22,31 +23,52 @@ namespace Microsoft.Restier.Samples.Northwind.Tests
         [Fact]
         public async Task TestTakeIncludeTotalCount()
         {
-            QueryResult result = await this.api.QueryAsync(
-                new QueryRequest(this.OrdersQuery.OrderBy(o => o.OrderDate).Take(10)));
+            using (HttpConfiguration config = new HttpConfiguration())
+            {
+                using (HttpServer server = new HttpServer(config))
+                {
+                    WebApiConfig.RegisterNorthwind(config, server);
+                    QueryResult result = await this.api.QueryAsync(
+                        new QueryRequest(this.OrdersQuery.OrderBy(o => o.OrderDate).Take(10)));
 
-            var orderResults = result.Results.OfType<Order>();
-            Assert.Equal(10, orderResults.Count());
+                    var orderResults = result.Results.OfType<Order>();
+                    Assert.Equal(10, orderResults.Count());
+                }
+            }
         }
 
         [Fact]
         public async Task TestSkipIncludeTotalCount()
         {
-            QueryResult result = await this.api.QueryAsync(
-                new QueryRequest(this.OrdersQuery.OrderBy(o => o.OrderDate).Skip(10)));
+            using (HttpConfiguration config = new HttpConfiguration())
+            {
+                using (HttpServer server = new HttpServer(config))
+                {
+                    WebApiConfig.RegisterNorthwind(config, server);
+                    QueryResult result = await this.api.QueryAsync(
+                        new QueryRequest(this.OrdersQuery.OrderBy(o => o.OrderDate).Skip(10)));
 
-            var orderResults = result.Results.OfType<Order>();
-            Assert.Equal(820, orderResults.Count());
+                    var orderResults = result.Results.OfType<Order>();
+                    Assert.Equal(820, orderResults.Count());
+                }
+            }
         }
 
         [Fact]
         public async Task TestSkipTakeIncludeTotalCount()
         {
-            QueryResult result = await this.api.QueryAsync(
-                new QueryRequest(this.OrdersQuery.OrderBy(o => o.OrderDate).Skip(10).Take(25)));
+            using (HttpConfiguration config = new HttpConfiguration())
+            {
+                using (HttpServer server = new HttpServer(config))
+                {
+                    WebApiConfig.RegisterNorthwind(config, server);
+                    QueryResult result = await this.api.QueryAsync(
+                        new QueryRequest(this.OrdersQuery.OrderBy(o => o.OrderDate).Skip(10).Take(25)));
 
-            var orderResults = result.Results.OfType<Order>();
-            Assert.Equal(25, orderResults.Count());
+                    var orderResults = result.Results.OfType<Order>();
+                    Assert.Equal(25, orderResults.Count());
+                }
+            }
         }
 
         /// <summary>
@@ -56,11 +78,18 @@ namespace Microsoft.Restier.Samples.Northwind.Tests
         [Fact]
         public async Task TestTakeNotStrippedIncludeTotalCount()
         {
-            QueryResult result = await this.api.QueryAsync(
-                new QueryRequest(this.OrdersQuery.Take(10).OrderBy(o => o.OrderDate)));
+            using (HttpConfiguration config = new HttpConfiguration())
+            {
+                using (HttpServer server = new HttpServer(config))
+                {
+                    WebApiConfig.RegisterNorthwind(config, server);
+                    QueryResult result = await this.api.QueryAsync(
+                        new QueryRequest(this.OrdersQuery.Take(10).OrderBy(o => o.OrderDate)));
 
-            var orderResults = result.Results.OfType<Order>();
-            Assert.Equal(10, orderResults.Count());
+                    var orderResults = result.Results.OfType<Order>();
+                    Assert.Equal(10, orderResults.Count());
+                }
+            }
         }
     }
 }

--- a/test/ODataEndToEndTests/Microsoft.Restier.Samples.Northwind/App_Start/WebApiConfig.cs
+++ b/test/ODataEndToEndTests/Microsoft.Restier.Samples.Northwind/App_Start/WebApiConfig.cs
@@ -6,6 +6,7 @@ using System.Web.OData.Extensions;
 using Microsoft.Restier.Samples.Northwind.Models;
 using Microsoft.Restier.WebApi;
 using Microsoft.Restier.WebApi.Batch;
+using Microsoft.Restier.WebApi.Routing;
 
 namespace Microsoft.Restier.Samples.Northwind
 {

--- a/test/ODataEndToEndTests/Microsoft.Restier.Samples.Northwind/Models/NorthwindApi.cs
+++ b/test/ODataEndToEndTests/Microsoft.Restier.Samples.Northwind/Models/NorthwindApi.cs
@@ -74,16 +74,16 @@ namespace Microsoft.Restier.Samples.Northwind.Models
             // Add core and conversion's services
             services = services.AddCoreServices(apiType)
                 .AddAttributeServices(apiType)
-                .AddConventionServices(apiType);
+                .AddConventionBasedServices(apiType);
 
             // Add EF related services
-            services.AddDbContextServices<NorthwindContext>();
+            services.AddEfProviderServices<NorthwindContext>();
 
             // Add customized services, after EF model builder and before WebApi operation model builder
             services.ChainPrevious<IModelBuilder, NorthwindModelExtender>();
 
             // This is used to add the publisher's services
-            ApiConfiguration.GetInternalServiceCallback(apiType)(services);
+            ApiConfiguration.GetPublisherServiceCallback(apiType)(services);
 
             return services;
         }

--- a/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Services.Trippin/App_Start/WebApiConfig.cs
+++ b/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Services.Trippin/App_Start/WebApiConfig.cs
@@ -3,6 +3,7 @@
 
 using System.Web.Http;
 using Microsoft.Restier.WebApi.Batch;
+using Microsoft.Restier.WebApi.Routing;
 using Microsoft.Restier.WebApi.Test.Services.Trippin.Api;
 
 namespace Microsoft.Restier.WebApi.Test.Services.Trippin

--- a/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Services.TrippinInMemory/App_Start/WebApiConfig.cs
+++ b/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Services.TrippinInMemory/App_Start/WebApiConfig.cs
@@ -1,5 +1,6 @@
 ﻿using System.Web.Http;
 using Microsoft.Restier.WebApi.Batch;
+using Microsoft.Restier.WebApi.Routing;
 
 namespace Microsoft.Restier.WebApi.Test.Services.TrippinInMemory
 {

--- a/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Services.TrippinInMemory/Models/TrippinApi.cs
+++ b/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Services.TrippinInMemory/Models/TrippinApi.cs
@@ -181,8 +181,8 @@ namespace Microsoft.Restier.WebApi.Test.Services.TrippinInMemory
 
         protected override IServiceCollection ConfigureApi(IServiceCollection services)
         {
-            return base.ConfigureApi(services)
-                .CutoffPrevious<IModelBuilder>(new ModelBuilder());
+            services.CutoffPrevious<IModelBuilder>(new ModelBuilder());
+            return base.ConfigureApi(services);
         }
 
         private class ModelBuilder : IModelBuilder


### PR DESCRIPTION
For this PR, I mainly made such changes,
1. For the internal services, uses central class to register all services.
2. As core can not refer to WebApi, keep InternalServiceCallback for WebApi to add service, and then call added the services.
3. For end user, they can add as inner most or out most, and if then want to add service between some RESTier service, they just copy existing configureApi content and add service between RESTier service call. Northwind API is an example.
4. I keep conversion as we discussed. And make attributes as it is now(we will not ship this at first GA, it is not a concerns).

I have passed build and all test cases, still thinking some renames, any comments, let me know.