### PR TITLE
Allow to customized OData query and validation setting.

### DIFF
--- a/src/Microsoft.Restier.WebApi/RestierController.cs
+++ b/src/Microsoft.Restier.WebApi/RestierController.cs
@@ -441,11 +441,7 @@ namespace Microsoft.Restier.WebApi
             ODataQueryOptions queryOptions = new ODataQueryOptions(queryContext, this.Request);
 
             // TODO GitHubIssue#41 : Ensure stable ordering for query
-            ODataQuerySettings settings = new ODataQuerySettings
-            {
-                HandleNullPropagation = HandleNullPropagationOption.False,
-                PageSize = null,  // no support for server enforced PageSize, yet
-            };
+            ODataQuerySettings settings = Api.Context.GetApiService<ODataQuerySettings>();
 
             if (this.shouldReturnCount)
             {
@@ -464,8 +460,7 @@ namespace Microsoft.Restier.WebApi
             }
 
             // Validate query before apply, and query setting like MaxExpansionDepth can be customized here
-            // TODO GitHubIssue#359 : Allow user to customize the query and validation setting
-            ODataValidationSettings validationSettings = new ODataValidationSettings();
+            ODataValidationSettings validationSettings = Api.Context.GetApiService<ODataValidationSettings>();
             queryOptions.Validate(validationSettings);
 
             // Entity count can NOT be evaluated at this point of time because the source

--- a/src/Microsoft.Restier.WebApi/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Restier.WebApi/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Web.OData.Query;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Restier.Core;
 using Microsoft.Restier.Core.Query;
@@ -13,6 +14,17 @@ namespace Microsoft.Restier.WebApi
         {
             RestierModelExtender.ApplyTo(services, typeof(T));
             RestierOperationModelBuilder.ApplyTo(services, typeof(T));
+
+            // Add OData Query Settings and valiadtion settings
+            Func<IServiceProvider, ODataQuerySettings> querySettingFactory = (sp) => new ODataQuerySettings
+            {
+                HandleNullPropagation = HandleNullPropagationOption.False,
+                PageSize = null,  // no support for server enforced PageSize, yet
+            };
+
+            services.AddSingleton<ODataQuerySettings>(querySettingFactory);
+            services.AddSingleton<ODataValidationSettings>();
+
             return
                 services.AddScoped<RestierQueryExecutorOptions>()
                     .ChainPrevious<IQueryExecutor, RestierQueryExecutor>();

--- a/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Scenario/UrlConventionsTests.cs
+++ b/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Scenario/UrlConventionsTests.cs
@@ -236,14 +236,14 @@ namespace Microsoft.Restier.WebApi.Test.Scenario
         public void ApplyingMutiLevelExpand()
         {
             TestGetPayloadContains(
-                "People?$expand=Friends($levels=2)", "http://localhost:18384/api/Trippin/$metadata#People");
+                "People?$expand=Friends($levels=3)", "http://localhost:18384/api/Trippin/$metadata#People");
         }
 
         [Fact]
         public void ApplyingLevelThanMaxExpand()
         {
             Action test = () => TestGetPayloadContains(
-                "People?$expand=Friends($levels=3)", "The request includes a $expand path which is too deep. The maximum depth allowed is 2. To increase the limit, set the 'MaxExpansionDepth' property on EnableQueryAttribute or ODataValidationSettings.");
+                "People?$expand=Friends($levels=4)", "The request includes a $expand path which is too deep. The maximum depth allowed is 2. To increase the limit, set the 'MaxExpansionDepth' property on EnableQueryAttribute or ODataValidationSettings.");
             // OData .NET client has wrapped the expcetion with new message.
             test.ShouldThrow<DataServiceTransportException>();
         }

--- a/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Services.Trippin/Api/TrippinApi.cs
+++ b/test/ODataEndToEndTests/Microsoft.Restier.WebApi.Test.Services.Trippin/Api/TrippinApi.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Web.OData.Query;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OData.Core;
 using Microsoft.Restier.Core;
@@ -139,8 +141,17 @@ namespace Microsoft.Restier.WebApi.Test.Services.Trippin.Api
 
         protected override IServiceCollection ConfigureApi(IServiceCollection services)
         {
+
+            // Add OData Query Settings and valiadtion settings
+            Func<IServiceProvider, ODataValidationSettings> validationSettingFactory = (sp) => new ODataValidationSettings
+            {
+                MaxAnyAllExpressionDepth =3,
+                MaxExpansionDepth = 3
+            };
+
             return base.ConfigureApi(services)
-                .AddSingleton<ODataPayloadValueConverter, CustomizedPayloadValueConverter>();
+                .AddSingleton<ODataPayloadValueConverter, CustomizedPayloadValueConverter>()
+                .AddSingleton<ODataValidationSettings>(validationSettingFactory);
         }
     }
 }


### PR DESCRIPTION
### Issues
*This pull request fixes issue #359 .*  

### Description
Make ODataQuerySetting and ODataValicationSetting as DI service so user can customize the settings.

### Checklist (Uncheck if it is not completed)
- [ x ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary
Document is needed.