### PR TITLE
Prevent WebApi services from being registered for multiple times.

### DIFF
--- a/src/Microsoft.Restier.WebApi/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Restier.WebApi/ServiceCollectionExtensions.cs
@@ -11,6 +11,11 @@ namespace Microsoft.Restier.WebApi
     {
         public static IServiceCollection AddWebApiServices<T>(this IServiceCollection services)
         {
+            if (services.HasService<RestierQueryExecutorOptions>())
+            {
+                return services;
+            }
+
             RestierModelExtender.ApplyTo(services, typeof(T));
             RestierOperationModelBuilder.ApplyTo(services, typeof(T));
             return


### PR DESCRIPTION
In Northwind test AddWebApiServices could possibly be called more than once, causing several model extenders registered and results in wrong EDM model.
I'm curious why Northwind tests still pass, but Northwind.EF7 tests aren't that lucky.