### PR TITLE
Removed the Default Value of the property

### DIFF
--- a/src/Microsoft.Restier.WebApi/Model/OperationAttribute.cs
+++ b/src/Microsoft.Restier.WebApi/Model/OperationAttribute.cs
@@ -36,6 +36,6 @@ namespace Microsoft.Restier.WebApi.Model
         /// If a operation does not have side effect, it means it is a function.
         /// If a operation has side effect, it means it is a action.
         /// </summary>
-        public bool HasSideEffects { get; set; } = false;
+        public bool HasSideEffects { get; set; }
     }
 }


### PR DESCRIPTION
### Issues
There is no active issue yet.

### Description
**build.cmd** 's current logic picks **MSBuild12** first which doesn't support Default Value on Properties

### Checklist (Uncheck if it is not completed)
- [  ] Test cases added
- [  ] Build and test with one-click build and test script passed