### PR TITLE
Update wrong project filename

### DIFF
--- a/BuildNuGets.cmd
+++ b/BuildNuGets.cmd
@@ -23,7 +23,7 @@ set params=-Prop Configuration=%config% -OutputDirectory bin\nuget\%config%
 .nuget\NuGet pack src\Microsoft.Restier.Core\Microsoft.Restier.Core.csproj %params%
 .nuget\NuGet pack src\Microsoft.Restier.Security\Microsoft.Restier.Security.csproj %params%
 .nuget\NuGet pack src\Microsoft.Restier.EntityFramework\Microsoft.Restier.EntityFramework.csproj %params%
-.nuget\NuGet pack src\Microsoft.Restier.WebApi\Microsoft.Restier.WebApi.csproj %params%
+.nuget\NuGet pack src\Microsoft.Restier.WebApi\Microsoft.Restier.OData.csproj %params%
 .nuget\NuGet pack src\Microsoft.Restier\Microsoft.Restier.nuspec %params%
 
 popd


### PR DESCRIPTION
### Description
Project file name changed from WebApi to OData.  This file had the old project filename.

### Checklist (Uncheck if it is not completed)
- [  ] Test cases added
- [ x ] Build and test with one-click build and test script passed
