### PR TITLE
Remove unnecessary EFCore configuration code in sample projects.

### DIFF
--- a/src/Microsoft.Restier.Providers.EntityFramework7/Submit/ChangeSetInitializer.cs
+++ b/src/Microsoft.Restier.Providers.EntityFramework7/Submit/ChangeSetInitializer.cs
@@ -45,6 +45,13 @@ namespace Microsoft.Restier.Providers.EntityFramework.Submit
             {
                 object strongTypedDbSet = dbContext.GetType().GetProperty(entry.EntitySetName).GetValue(dbContext);
                 Type entityType = strongTypedDbSet.GetType().GetGenericArguments()[0];
+
+                // This means request entity is sub type of entity type
+                if (entry.ActualEntityType != null && entityType != entry.ActualEntityType)
+                {
+                    entityType = entry.ActualEntityType;
+                }
+
                 MethodInfo prepareEntryMethod = prepareEntryGeneric.MakeGenericMethod(entityType);
 
                 var task = (Task)prepareEntryMethod.Invoke(

--- a/test/Microsoft.Restier.Providers.EntityFramework7.Tests/DateTests.cs
+++ b/test/Microsoft.Restier.Providers.EntityFramework7.Tests/DateTests.cs
@@ -10,6 +10,7 @@ using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Library;
 using Microsoft.Restier.Core;
 using Microsoft.Restier.Providers.EntityFramework7.Tests.Models.Primitives;
+using Microsoft.Restier.Publishers.OData;
 using Microsoft.Restier.Publishers.OData.Batch;
 using Microsoft.Restier.Publishers.OData.Routing;
 using Microsoft.Restier.Tests;
@@ -23,11 +24,15 @@ namespace Microsoft.Restier.Providers.EntityFramework7.Tests
         [Fact]
         public async Task VerifyMetadataPropertyType()
         {
+            ApiConfiguration.AddPublisherServices<PrimitivesApi>(services =>
+            {
+                services.AddODataServices<PrimitivesApi>();
+            });
             var api = new PrimitivesApi();
             var edmModel = await api.GetModelAsync();
 
             var entityType = (IEdmEntityType)
-                edmModel.FindDeclaredType(@"Microsoft.Restier.Providers.EntityFramework.Tests.Models.Primitives.DateItem");
+                edmModel.FindDeclaredType(@"Microsoft.Restier.Providers.EntityFramework7.Tests.Models.Primitives.DateItem");
             Assert.NotNull(entityType);
 
             Assert.True(entityType.FindProperty("DTProperty").Type.IsDateTimeOffset());

--- a/test/Microsoft.Restier.Providers.EntityFramework7.Tests/Models/Primitives/PrimitivesApi.cs
+++ b/test/Microsoft.Restier.Providers.EntityFramework7.Tests/Models/Primitives/PrimitivesApi.cs
@@ -23,15 +23,6 @@ namespace Microsoft.Restier.Providers.EntityFramework7.Tests.Models.Primitives
             base.OnConfiguring(optionsBuilder);
         }
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            base.OnModelCreating(modelBuilder);
-
-            modelBuilder.Entity<DateItem>().HasKey(e => e.RowId);
-            modelBuilder.Entity<DateItem>().Property(e => e.DateProperty).HasColumnType("date");
-            modelBuilder.Entity<DateItem>().Property(e => e.TODProperty).HasColumnType("time");
-        }
-
         public DbSet<DateItem> Dates { get; set; }
     }
 

--- a/test/ODataEndToEnd/Microsoft.OData.Service.Sample.Northwind.EF7.Tests/Microsoft.OData.Service.Sample.Northwind.EF7.Tests.csproj
+++ b/test/ODataEndToEnd/Microsoft.OData.Service.Sample.Northwind.EF7.Tests/Microsoft.OData.Service.Sample.Northwind.EF7.Tests.csproj
@@ -221,36 +221,47 @@
     </Content>
     <Content Include="..\Microsoft.OData.Service.Sample.Northwind.Tests\Baselines\TestBatch.txt">
       <Link>Baselines\TestBatch.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\Microsoft.OData.Service.Sample.Northwind.Tests\Baselines\TestCustomerKeyAsSegment.txt">
       <Link>Baselines\TestCustomerKeyAsSegment.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\Microsoft.OData.Service.Sample.Northwind.Tests\Baselines\TestCustomersEntitySetCountQuery.txt">
       <Link>Baselines\TestCustomersEntitySetCountQuery.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\Microsoft.OData.Service.Sample.Northwind.Tests\Baselines\TestCustomersEntitySetQuery.txt">
       <Link>Baselines\TestCustomersEntitySetQuery.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\Microsoft.OData.Service.Sample.Northwind.Tests\Baselines\TestCustomersEntitySetTopSkipQuery.txt">
       <Link>Baselines\TestCustomersEntitySetTopSkipQuery.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\Microsoft.OData.Service.Sample.Northwind.Tests\Baselines\TestGetNorthwindMetadata.txt">
       <Link>Baselines\TestGetNorthwindMetadata.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\Microsoft.OData.Service.Sample.Northwind.Tests\Baselines\TestOrdersEntitySetAutoExpandQuery.txt">
       <Link>Baselines\TestOrdersEntitySetAutoExpandQuery.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\Microsoft.OData.Service.Sample.Northwind.Tests\Baselines\TestPatchProductReturnContent.txt">
       <Link>Baselines\TestPatchProductReturnContent.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\Microsoft.OData.Service.Sample.Northwind.Tests\Baselines\TestPostAction.txt">
       <Link>Baselines\TestPostAction.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\Microsoft.OData.Service.Sample.Northwind.Tests\Baselines\TestPostOrderInvalidShipVia.txt">
       <Link>Baselines\TestPostOrderInvalidShipVia.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\Microsoft.OData.Service.Sample.Northwind.Tests\Baselines\TestPutProductReturnContent.txt">
       <Link>Baselines\TestPutProductReturnContent.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
   <ItemGroup />

--- a/test/ODataEndToEnd/Microsoft.OData.Service.Sample.Northwind/Models/NorthwindContext.cs
+++ b/test/ODataEndToEnd/Microsoft.OData.Service.Sample.Northwind/Models/NorthwindContext.cs
@@ -91,64 +91,8 @@ namespace Microsoft.OData.Service.Sample.Northwind.Models
             // TODO GitHubIssue#57: Complete EF7 to EDM model mapping
             // After EF7 adds support for DataAnnotation, some of following configuration could be deprecated.
 
-            modelBuilder.Entity<Category>(entityBuilder =>
-            {
-                entityBuilder.ToTable("Categories");
-                entityBuilder.Property(e => e.CategoryName).IsRequired().HasMaxLength(15);
-                entityBuilder.Property(e => e.Description).HasColumnType("ntext");
-                entityBuilder.Property(e => e.Picture).HasColumnType("image");
-                entityBuilder.Property(e => e.CategoryName).HasMaxLength(15);
-                entityBuilder.HasKey(e => e.CategoryID);
-            });
-
-
-            modelBuilder.Entity<Contact>(entityBuilder =>
-            {
-                entityBuilder.ToTable("Contacts");
-                entityBuilder.Property(e => e.HomePage).HasColumnType("ntext");
-                entityBuilder.Property(e => e.Photo).HasColumnType("image");
-                //entityBuilder.Key(e => e.ContactID);
-            });
-
-            modelBuilder.Entity<Customer>(entityBuilder =>
-            {
-                entityBuilder.ToTable("Customers");
-                entityBuilder.Property(e => e.CompanyName).IsRequired().HasMaxLength(40);
-                entityBuilder.HasKey(e => e.CustomerID);
-            });
-
-            modelBuilder.Entity<CustomerDemographic>(entityBuilder =>
-            {
-                entityBuilder.ToTable("CustomerDemographics");
-            });
-
-            modelBuilder.Entity<Employee>(entityBuilder =>
-            {
-                entityBuilder.ToTable("Employees");
-                entityBuilder.Property(e => e.LastName).IsRequired().HasMaxLength(20);
-                entityBuilder.Property(e => e.FirstName).IsRequired().HasMaxLength(10);
-				entityBuilder.Property(e => e.BirthDate).HasColumnType("date");
-				entityBuilder.Property(e => e.HireDate).HasColumnType("date");
-				entityBuilder.HasMany(e => e.Employees1)
-                    .WithOne(e => e.Employee1)
-                    .IsRequired(false)
-                    .HasForeignKey(e => e.ReportsTo);
-            });
-
-            modelBuilder.Entity<Order>(entityBuilder =>
-            {
-                entityBuilder.ToTable("Orders");
-				entityBuilder.Property(e => e.OrderDate).HasColumnType("date");
-				entityBuilder.Property(e => e.RequiredDate).HasColumnType("date");
-				entityBuilder.Property(e => e.ShippedDate).HasColumnType("date");
-				entityBuilder.HasMany(e => e.Order_Details).WithOne(e => e.Order)
-                    .IsRequired()
-                    .HasForeignKey(e => e.OrderID).OnDelete(DeleteBehavior.Cascade);
-            });
-
             modelBuilder.Entity<Order_Detail>(entityBuilder =>
             {
-                entityBuilder.ToTable("Order Details");
                 entityBuilder.Property(e => e.UnitPrice).HasColumnType("money");
                 entityBuilder.HasKey(e => new
                 {
@@ -157,44 +101,28 @@ namespace Microsoft.OData.Service.Sample.Northwind.Models
                 });
             });
 
-            modelBuilder.Entity<Product>(entityBuilder =>
-            {
-                entityBuilder.ToTable("Products");
-                entityBuilder.Property(e => e.UnitPrice).HasColumnType("money");
-                entityBuilder.HasMany(e => e.Order_Details)
-                    .WithOne(e => e.Product)
-                    .IsRequired()
-                    .HasForeignKey(e => e.ProductID)
-                    .OnDelete(DeleteBehavior.Cascade);
-            });
-
-            modelBuilder.Entity<Region>(entityBuilder =>
-            {
-                entityBuilder.Property(e => e.RegionDescription).IsRequired();
-                entityBuilder.HasKey(e => e.RegionID);
-            });
-
             modelBuilder.Entity<Shipper>(entityBuilder =>
             {
-                entityBuilder.ToTable("Shippers");
                 entityBuilder.HasMany(e => e.Orders)
                     .WithOne(e => e.Shipper)
                     .HasForeignKey(e => e.ShipVia)
                     .IsRequired(false);
             });
 
-            modelBuilder.Entity<Supplier>(entityBuilder =>
+            modelBuilder.Entity<Order>(entityBuilder =>
             {
+                entityBuilder.HasMany(e => e.Order_Details).WithOne(e => e.Order)
+                    .IsRequired()
+                    .HasForeignKey(e => e.OrderID).OnDelete(DeleteBehavior.Restrict);
             });
 
-            modelBuilder.Entity<Territory>(entityBuilder =>
+            modelBuilder.Entity<Product>(entityBuilder =>
             {
-                entityBuilder.ToTable("Territories");
-                entityBuilder.HasOne(e => e.Region)
-                    .WithMany(e => e.Territories)
-                    .HasForeignKey(e => e.RegionID)
+                entityBuilder.HasMany(e => e.Order_Details)
+                    .WithOne(e => e.Product)
                     .IsRequired()
-                    .OnDelete(DeleteBehavior.Cascade);
+                    .HasForeignKey(e => e.ProductID)
+                    .OnDelete(DeleteBehavior.Restrict);
             });
 
             // TODO GitHubIssue#57: Complete EF7 to EDM model mapping

--- a/test/ODataEndToEnd/Microsoft.OData.Service.Sample.Northwind/Models/NorthwindContext.cs
+++ b/test/ODataEndToEnd/Microsoft.OData.Service.Sample.Northwind/Models/NorthwindContext.cs
@@ -88,9 +88,6 @@ namespace Microsoft.OData.Service.Sample.Northwind.Models
 
             modelBuilder.ForSqlServerUseIdentityColumns();
 
-            // TODO GitHubIssue#57: Complete EF7 to EDM model mapping
-            // After EF7 adds support for DataAnnotation, some of following configuration could be deprecated.
-
             modelBuilder.Entity<Order_Detail>(entityBuilder =>
             {
                 entityBuilder.Property(e => e.UnitPrice).HasColumnType("money");


### PR DESCRIPTION
- EFCore RC2 supports quite a few annotations now, remove unnecessary configuration code in samples.
- Add derived type support to EFCore submit pipeline.

There're 5 UT failures in Sample.Tests, I believe not related to this change.