### PR TITLE
Improve model built exception been thrown

### DIFF
--- a/src/Microsoft.Restier.Publishers.OData/Model/RestierModelBuilder.cs
+++ b/src/Microsoft.Restier.Publishers.OData/Model/RestierModelBuilder.cs
@@ -35,6 +35,8 @@ namespace Microsoft.Restier.Publishers.OData.Model
             }
 
             // Collection is set by EF now, and EF model producer will not build model any more
+            // Web Api OData conversion model built is been used here,
+            // refer to Web Api OData document for the detail conversions been used for model built.
             var builder = new ODataConventionModelBuilder();
             MethodInfo method = typeof(ODataConventionModelBuilder)
                 .GetMethod("EntitySet", BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy);


### PR DESCRIPTION
### Issues
*This pull request fixes issue #432 .*  

### Description
If we use call api.GetModelAsync().Result, then the exception been thrown is wrapped and only inner exception has meaningful message.

If we change to await api.GetModelAsync(), then the exception been thrown will not be wrapped and the exception is meaningful.
