### PR TITLE
Make model auto pop keys from Entity framework.

### DIFF
--- a/src/GlobalSuppressions.cs
+++ b/src/GlobalSuppressions.cs
@@ -37,8 +37,8 @@ using System.Diagnostics.CodeAnalysis;
 #region CA1006 Nested Generic Type
 [assembly: SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Scope = "member", Target = "Microsoft.Restier.Core.ApiBaseExtensions.#QueryAsync`1(Microsoft.Restier.Core.ApiBase,System.Linq.IQueryable`1<!!0>,System.Threading.CancellationToken)")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Scope = "member", Target = "Microsoft.Restier.Core.ApiBaseExtensions.#QueryAsync`2(Microsoft.Restier.Core.ApiBase,System.Linq.IQueryable`1<!!0>,System.Linq.Expressions.Expression`1<System.Func`2<System.Linq.IQueryable`1<!!0>,!!1>>,System.Threading.CancellationToken)")]
+[assembly: SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Scope = "member", Target = "Microsoft.Restier.Core.Model.ModelContext.#EntityTypeKeyPropertiesMapDictionary")]
 [assembly: SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Scope = "member", Target = "Microsoft.Restier.Core.Query.QueryRequest.#Create`2(System.Linq.IQueryable`1<!!0>,System.Linq.Expressions.Expression`1<System.Func`2<System.Linq.IQueryable`1<!!0>,!!1>>,System.Nullable`1<System.Boolean>)")]
-[assembly: SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Scope = "member", Target = "Microsoft.Restier.Core.Model.ModelContext.#EntitySetTypeMapCollection")]
 #endregion
 
 #region CA1020 Few types in namespace
@@ -149,7 +149,8 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Microsoft.Usage", "CA2208:InstantiateArgumentExceptionsCorrectly", Scope = "member", Target = "Microsoft.Restier.Core.ApiContext.#.ctor(Microsoft.Restier.Core.ApiConfiguration)")]
 [assembly: SuppressMessage("Microsoft.Usage", "CA2208:InstantiateArgumentExceptionsCorrectly", Scope = "member", Target = "Microsoft.Restier.Core.QueryableSource.#System.Linq.IQueryProvider.CreateQuery`1(System.Linq.Expressions.Expression)")]
 [assembly: SuppressMessage("Microsoft.Usage", "CA2208:InstantiateArgumentExceptionsCorrectly", Scope = "member", Target = "Microsoft.Restier.Core.QueryableSource.#System.Linq.IQueryProvider.CreateQuery(System.Linq.Expressions.Expression)")]
-[assembly: SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly", Scope = "member", Target = "Microsoft.Restier.Core.Model.ModelContext.#EntitySetTypeMapCollection")]
+[assembly: SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly", Scope = "member", Target = "Microsoft.Restier.Core.Model.ModelContext.#EntitySetTypeMapDictionary")]
+[assembly: SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly", Scope = "member", Target = "Microsoft.Restier.Core.Model.ModelContext.#EntityTypeKeyPropertiesMapDictionary")]
 #endregion
 
 #region CA1801 Unused Parameters

--- a/src/Microsoft.Restier.Core/Model/ModelContext.cs
+++ b/src/Microsoft.Restier.Core/Model/ModelContext.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
+using System.Reflection;
 
 namespace Microsoft.Restier.Core.Model
 {
@@ -24,8 +24,16 @@ namespace Microsoft.Restier.Core.Model
         }
 
         /// <summary>
-        /// Gets or sets Entity set and entity type map collection, it will be used by publisher for model build.
+        /// Gets or sets Entity set and entity type map dictionary, it will be used by publisher for model build.
         /// </summary>
-        public Collection<KeyValuePair<string, Type>> EntitySetTypeMapCollection { get; set; }
+        public IDictionary<string, Type> EntitySetTypeMapDictionary { get; set; }
+
+        /// <summary>
+        /// Gets or sets entity type and its key properties map dictionary, and used by publisher for model build.
+        /// This is useful when key properties does not have key attribute
+        /// or follow Web Api OData key property naming convention.
+        /// Otherwise, this collection is not needed.
+        /// </summary>
+        public IDictionary<Type, ICollection<PropertyInfo>> EntityTypeKeyPropertiesMapDictionary { get; set; }
     }
 }

--- a/test/Microsoft.Restier.Publishers.OData.Test/Microsoft.Restier.Publishers.OData.Test.csproj
+++ b/test/Microsoft.Restier.Publishers.OData.Test/Microsoft.Restier.Publishers.OData.Test.csproj
@@ -35,8 +35,13 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="EntityFramework">
+    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0-rc2-final\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>

--- a/test/Microsoft.Restier.Publishers.OData.Test/app.config
+++ b/test/Microsoft.Restier.Publishers.OData.Test/app.config
@@ -1,5 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
+  <configSections>
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+  </configSections>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
@@ -16,4 +20,13 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
+  <entityFramework>
+    <providers>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+    </providers>
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
+  </entityFramework>
+  <connectionStrings>
+    <add name="LibraryContext" connectionString="data source=(localdb)\MSSQLLocalDB;initial catalog=LibraryAPIDB;integrated security=True;connect timeout=30;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient"/>
+  </connectionStrings>
 </configuration>

--- a/test/Microsoft.Restier.Publishers.OData.Test/packages.config
+++ b/test/Microsoft.Restier.Publishers.OData.Test/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="EntityFramework" version="6.1.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.OData" version="5.9.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />

--- a/test/Microsoft.Restier.TestCommon/PublicApi.bsl
+++ b/test/Microsoft.Restier.TestCommon/PublicApi.bsl
@@ -299,7 +299,8 @@ public interface Microsoft.Restier.Core.Model.IModelMapper {
 public class Microsoft.Restier.Core.Model.ModelContext : Microsoft.Restier.Core.InvocationContext {
 	public ModelContext (Microsoft.Restier.Core.ApiContext apiContext)
 
-	System.Collections.ObjectModel.Collection`1[[System.Collections.Generic.KeyValuePair`2[[System.String],[System.Type]]]] EntitySetTypeMapCollection  { [CompilerGeneratedAttribute(),]public get; [CompilerGeneratedAttribute(),]public set; }
+	System.Collections.Generic.IDictionary`2[[System.String],[System.Type]] EntitySetTypeMapDictionary  { [CompilerGeneratedAttribute(),]public get; [CompilerGeneratedAttribute(),]public set; }
+	System.Collections.Generic.IDictionary`2[[System.Type],[System.Collections.Generic.ICollection`1[[System.Reflection.PropertyInfo]]]] EntityTypeKeyPropertiesMapDictionary  { [CompilerGeneratedAttribute(),]public get; [CompilerGeneratedAttribute(),]public set; }
 }
 
 public interface Microsoft.Restier.Core.Query.IQueryExecutor {

--- a/test/ODataEndToEnd/Microsoft.OData.Service.Sample.Northwind.Tests/Baselines/TestGetNorthwindMetadata.txt
+++ b/test/ODataEndToEnd/Microsoft.OData.Service.Sample.Northwind.Tests/Baselines/TestGetNorthwindMetadata.txt
@@ -12,81 +12,27 @@
         <Property Name="Picture" Type="Edm.Binary" />
         <NavigationProperty Name="Products" Type="Collection(Microsoft.OData.Service.Sample.Northwind.Models.Product)" />
       </EntityType>
-      <EntityType Name="Contact">
+      <EntityType Name="Product">
         <Key>
-          <PropertyRef Name="ContactID" />
+          <PropertyRef Name="ProductID" />
         </Key>
-        <Property Name="ContactID" Type="Edm.Int32" Nullable="false" />
-        <Property Name="ContactType" Type="Edm.String" />
-        <Property Name="CompanyName" Type="Edm.String" Nullable="false" />
-        <Property Name="ContactName" Type="Edm.String" />
-        <Property Name="ContactTitle" Type="Edm.String" />
-        <Property Name="Address" Type="Edm.String" />
-        <Property Name="City" Type="Edm.String" />
-        <Property Name="Region" Type="Edm.String" />
-        <Property Name="PostalCode" Type="Edm.String" />
-        <Property Name="CountryRegion" Type="Edm.String" />
-        <Property Name="Phone" Type="Edm.String" />
-        <Property Name="Extension" Type="Edm.String" />
-        <Property Name="Fax" Type="Edm.String" />
-        <Property Name="HomePage" Type="Edm.String" />
-        <Property Name="PhotoPath" Type="Edm.String" />
-        <Property Name="Photo" Type="Edm.Binary" />
-      </EntityType>
-      <EntityType Name="CustomerDemographic">
-        <Key>
-          <PropertyRef Name="CustomerTypeID" />
-        </Key>
-        <Property Name="CustomerTypeID" Type="Edm.String" Nullable="false" />
-        <Property Name="CustomerDesc" Type="Edm.String" />
-        <NavigationProperty Name="Customers" Type="Collection(Microsoft.OData.Service.Sample.Northwind.Models.Customer)" />
-      </EntityType>
-      <EntityType Name="Customer">
-        <Key>
-          <PropertyRef Name="CustomerID" />
-        </Key>
-        <Property Name="CustomerID" Type="Edm.String" Nullable="false" />
-        <Property Name="CompanyName" Type="Edm.String" Nullable="false" />
-        <Property Name="ContactName" Type="Edm.String" />
-        <Property Name="ContactTitle" Type="Edm.String" />
-        <Property Name="Address" Type="Edm.String" />
-        <Property Name="City" Type="Edm.String" />
-        <Property Name="Region" Type="Edm.String" />
-        <Property Name="PostalCode" Type="Edm.String" />
-        <Property Name="CountryRegion" Type="Edm.String" />
-        <Property Name="Phone" Type="Edm.String" />
-        <Property Name="Fax" Type="Edm.String" />
-        <NavigationProperty Name="Orders" Type="Collection(Microsoft.OData.Service.Sample.Northwind.Models.Order)" />
-        <NavigationProperty Name="CustomerDemographics" Type="Collection(Microsoft.OData.Service.Sample.Northwind.Models.CustomerDemographic)" />
-      </EntityType>
-      <EntityType Name="Employee">
-        <Key>
-          <PropertyRef Name="EmployeeID" />
-        </Key>
-        <Property Name="EmployeeID" Type="Edm.Int32" />
-        <Property Name="LastName" Type="Edm.String" Nullable="false" />
-        <Property Name="FirstName" Type="Edm.String" Nullable="false" />
-        <Property Name="Title" Type="Edm.String" />
-        <Property Name="TitleOfCourtesy" Type="Edm.String" />
-        <Property Name="BirthDate" Type="Edm.Date" />
-        <Property Name="HireDate" Type="Edm.Date" />
-        <Property Name="Address" Type="Edm.String" />
-        <Property Name="City" Type="Edm.String" />
-        <Property Name="Region" Type="Edm.String" />
-        <Property Name="PostalCode" Type="Edm.String" />
-        <Property Name="CountryRegion" Type="Edm.String" />
-        <Property Name="HomePhone" Type="Edm.String" />
-        <Property Name="Extension" Type="Edm.String" />
-        <Property Name="Photo" Type="Edm.Binary" />
-        <Property Name="Notes" Type="Edm.String" />
-        <Property Name="ReportsTo" Type="Edm.Int32" />
-        <Property Name="PhotoPath" Type="Edm.String" />
-        <NavigationProperty Name="Employees1" Type="Collection(Microsoft.OData.Service.Sample.Northwind.Models.Employee)" />
-        <NavigationProperty Name="Employee1" Type="Microsoft.OData.Service.Sample.Northwind.Models.Employee">
-          <ReferentialConstraint Property="EmployeeID" ReferencedProperty="EmployeeID" />
+        <Property Name="ProductID" Type="Edm.Int32" Nullable="false" />
+        <Property Name="ProductName" Type="Edm.String" Nullable="false" />
+        <Property Name="SupplierID" Type="Edm.Int32" />
+        <Property Name="CategoryID" Type="Edm.Int32" />
+        <Property Name="QuantityPerUnit" Type="Edm.String" />
+        <Property Name="UnitPrice" Type="Edm.Decimal" />
+        <Property Name="UnitsInStock" Type="Edm.Int16" />
+        <Property Name="UnitsOnOrder" Type="Edm.Int16" />
+        <Property Name="ReorderLevel" Type="Edm.Int16" />
+        <Property Name="Discontinued" Type="Edm.Boolean" Nullable="false" />
+        <NavigationProperty Name="Category" Type="Microsoft.OData.Service.Sample.Northwind.Models.Category">
+          <ReferentialConstraint Property="CategoryID" ReferencedProperty="CategoryID" />
         </NavigationProperty>
-        <NavigationProperty Name="Orders" Type="Collection(Microsoft.OData.Service.Sample.Northwind.Models.Order)" />
-        <NavigationProperty Name="Territories" Type="Collection(Microsoft.OData.Service.Sample.Northwind.Models.Territory)" />
+        <NavigationProperty Name="Order_Details" Type="Collection(Microsoft.OData.Service.Sample.Northwind.Models.Order_Detail)" />
+        <NavigationProperty Name="Supplier" Type="Microsoft.OData.Service.Sample.Northwind.Models.Supplier">
+          <ReferentialConstraint Property="SupplierID" ReferencedProperty="SupplierID" />
+        </NavigationProperty>
       </EntityType>
       <EntityType Name="Order_Detail">
         <Key>
@@ -132,27 +78,72 @@
         <NavigationProperty Name="Order_Details" Type="Collection(Microsoft.OData.Service.Sample.Northwind.Models.Order_Detail)" />
         <NavigationProperty Name="Shipper" Type="Microsoft.OData.Service.Sample.Northwind.Models.Shipper" />
       </EntityType>
-      <EntityType Name="Product">
+      <EntityType Name="Customer">
         <Key>
-          <PropertyRef Name="ProductID" />
+          <PropertyRef Name="CustomerID" />
         </Key>
-        <Property Name="ProductID" Type="Edm.Int32" Nullable="false" />
-        <Property Name="ProductName" Type="Edm.String" Nullable="false" />
-        <Property Name="SupplierID" Type="Edm.Int32" />
-        <Property Name="CategoryID" Type="Edm.Int32" />
-        <Property Name="QuantityPerUnit" Type="Edm.String" />
-        <Property Name="UnitPrice" Type="Edm.Decimal" />
-        <Property Name="UnitsInStock" Type="Edm.Int16" />
-        <Property Name="UnitsOnOrder" Type="Edm.Int16" />
-        <Property Name="ReorderLevel" Type="Edm.Int16" />
-        <Property Name="Discontinued" Type="Edm.Boolean" Nullable="false" />
-        <NavigationProperty Name="Category" Type="Microsoft.OData.Service.Sample.Northwind.Models.Category">
-          <ReferentialConstraint Property="CategoryID" ReferencedProperty="CategoryID" />
+        <Property Name="CustomerID" Type="Edm.String" Nullable="false" />
+        <Property Name="CompanyName" Type="Edm.String" Nullable="false" />
+        <Property Name="ContactName" Type="Edm.String" />
+        <Property Name="ContactTitle" Type="Edm.String" />
+        <Property Name="Address" Type="Edm.String" />
+        <Property Name="City" Type="Edm.String" />
+        <Property Name="Region" Type="Edm.String" />
+        <Property Name="PostalCode" Type="Edm.String" />
+        <Property Name="CountryRegion" Type="Edm.String" />
+        <Property Name="Phone" Type="Edm.String" />
+        <Property Name="Fax" Type="Edm.String" />
+        <NavigationProperty Name="Orders" Type="Collection(Microsoft.OData.Service.Sample.Northwind.Models.Order)" />
+        <NavigationProperty Name="CustomerDemographics" Type="Collection(Microsoft.OData.Service.Sample.Northwind.Models.CustomerDemographic)" />
+      </EntityType>
+      <EntityType Name="CustomerDemographic">
+        <Key>
+          <PropertyRef Name="CustomerTypeID" />
+        </Key>
+        <Property Name="CustomerTypeID" Type="Edm.String" Nullable="false" />
+        <Property Name="CustomerDesc" Type="Edm.String" />
+        <NavigationProperty Name="Customers" Type="Collection(Microsoft.OData.Service.Sample.Northwind.Models.Customer)" />
+      </EntityType>
+      <EntityType Name="Employee">
+        <Key>
+          <PropertyRef Name="EmployeeID" />
+        </Key>
+        <Property Name="EmployeeID" Type="Edm.Int32" />
+        <Property Name="LastName" Type="Edm.String" Nullable="false" />
+        <Property Name="FirstName" Type="Edm.String" Nullable="false" />
+        <Property Name="Title" Type="Edm.String" />
+        <Property Name="TitleOfCourtesy" Type="Edm.String" />
+        <Property Name="BirthDate" Type="Edm.Date" />
+        <Property Name="HireDate" Type="Edm.Date" />
+        <Property Name="Address" Type="Edm.String" />
+        <Property Name="City" Type="Edm.String" />
+        <Property Name="Region" Type="Edm.String" />
+        <Property Name="PostalCode" Type="Edm.String" />
+        <Property Name="CountryRegion" Type="Edm.String" />
+        <Property Name="HomePhone" Type="Edm.String" />
+        <Property Name="Extension" Type="Edm.String" />
+        <Property Name="Photo" Type="Edm.Binary" />
+        <Property Name="Notes" Type="Edm.String" />
+        <Property Name="ReportsTo" Type="Edm.Int32" />
+        <Property Name="PhotoPath" Type="Edm.String" />
+        <NavigationProperty Name="Employees1" Type="Collection(Microsoft.OData.Service.Sample.Northwind.Models.Employee)" />
+        <NavigationProperty Name="Employee1" Type="Microsoft.OData.Service.Sample.Northwind.Models.Employee">
+          <ReferentialConstraint Property="EmployeeID" ReferencedProperty="EmployeeID" />
         </NavigationProperty>
-        <NavigationProperty Name="Order_Details" Type="Collection(Microsoft.OData.Service.Sample.Northwind.Models.Order_Detail)" />
-        <NavigationProperty Name="Supplier" Type="Microsoft.OData.Service.Sample.Northwind.Models.Supplier">
-          <ReferentialConstraint Property="SupplierID" ReferencedProperty="SupplierID" />
+        <NavigationProperty Name="Orders" Type="Collection(Microsoft.OData.Service.Sample.Northwind.Models.Order)" />
+        <NavigationProperty Name="Territories" Type="Collection(Microsoft.OData.Service.Sample.Northwind.Models.Territory)" />
+      </EntityType>
+      <EntityType Name="Territory">
+        <Key>
+          <PropertyRef Name="TerritoryID" />
+        </Key>
+        <Property Name="TerritoryID" Type="Edm.String" Nullable="false" />
+        <Property Name="TerritoryDescription" Type="Edm.String" Nullable="false" />
+        <Property Name="RegionID" Type="Edm.Int32" />
+        <NavigationProperty Name="Region" Type="Microsoft.OData.Service.Sample.Northwind.Models.Region">
+          <ReferentialConstraint Property="RegionID" ReferencedProperty="RegionID" />
         </NavigationProperty>
+        <NavigationProperty Name="Employees" Type="Collection(Microsoft.OData.Service.Sample.Northwind.Models.Employee)" />
       </EntityType>
       <EntityType Name="Region">
         <Key>
@@ -189,17 +180,26 @@
         <Property Name="HomePage" Type="Edm.String" />
         <NavigationProperty Name="Products" Type="Collection(Microsoft.OData.Service.Sample.Northwind.Models.Product)" />
       </EntityType>
-      <EntityType Name="Territory">
+      <EntityType Name="Contact">
         <Key>
-          <PropertyRef Name="TerritoryID" />
+          <PropertyRef Name="ContactID" />
         </Key>
-        <Property Name="TerritoryID" Type="Edm.String" Nullable="false" />
-        <Property Name="TerritoryDescription" Type="Edm.String" Nullable="false" />
-        <Property Name="RegionID" Type="Edm.Int32" />
-        <NavigationProperty Name="Region" Type="Microsoft.OData.Service.Sample.Northwind.Models.Region">
-          <ReferentialConstraint Property="RegionID" ReferencedProperty="RegionID" />
-        </NavigationProperty>
-        <NavigationProperty Name="Employees" Type="Collection(Microsoft.OData.Service.Sample.Northwind.Models.Employee)" />
+        <Property Name="ContactID" Type="Edm.Int32" Nullable="false" />
+        <Property Name="ContactType" Type="Edm.String" />
+        <Property Name="CompanyName" Type="Edm.String" Nullable="false" />
+        <Property Name="ContactName" Type="Edm.String" />
+        <Property Name="ContactTitle" Type="Edm.String" />
+        <Property Name="Address" Type="Edm.String" />
+        <Property Name="City" Type="Edm.String" />
+        <Property Name="Region" Type="Edm.String" />
+        <Property Name="PostalCode" Type="Edm.String" />
+        <Property Name="CountryRegion" Type="Edm.String" />
+        <Property Name="Phone" Type="Edm.String" />
+        <Property Name="Extension" Type="Edm.String" />
+        <Property Name="Fax" Type="Edm.String" />
+        <Property Name="HomePage" Type="Edm.String" />
+        <Property Name="PhotoPath" Type="Edm.String" />
+        <Property Name="Photo" Type="Edm.Binary" />
       </EntityType>
       <Function Name="MostExpensive" IsBound="true">
         <Parameter Name="bindingParameter" Type="Collection(Microsoft.OData.Service.Sample.Northwind.Models.Product)" />
@@ -216,19 +216,10 @@
         <EntitySet Name="Categories" EntityType="Microsoft.OData.Service.Sample.Northwind.Models.Category">
           <NavigationPropertyBinding Path="Products" Target="Products" />
         </EntitySet>
-        <EntitySet Name="Contacts" EntityType="Microsoft.OData.Service.Sample.Northwind.Models.Contact" />
-        <EntitySet Name="CustomerDemographics" EntityType="Microsoft.OData.Service.Sample.Northwind.Models.CustomerDemographic">
-          <NavigationPropertyBinding Path="Customers" Target="Customers" />
-        </EntitySet>
-        <EntitySet Name="Customers" EntityType="Microsoft.OData.Service.Sample.Northwind.Models.Customer">
-          <NavigationPropertyBinding Path="Orders" Target="Orders" />
-          <NavigationPropertyBinding Path="CustomerDemographics" Target="CustomerDemographics" />
-        </EntitySet>
-        <EntitySet Name="Employees" EntityType="Microsoft.OData.Service.Sample.Northwind.Models.Employee">
-          <NavigationPropertyBinding Path="Employees1" Target="Employees" />
-          <NavigationPropertyBinding Path="Employee1" Target="Employees" />
-          <NavigationPropertyBinding Path="Orders" Target="Orders" />
-          <NavigationPropertyBinding Path="Territories" Target="Territories" />
+        <EntitySet Name="Products" EntityType="Microsoft.OData.Service.Sample.Northwind.Models.Product">
+          <NavigationPropertyBinding Path="Category" Target="Categories" />
+          <NavigationPropertyBinding Path="Order_Details" Target="Order_Details" />
+          <NavigationPropertyBinding Path="Supplier" Target="Suppliers" />
         </EntitySet>
         <EntitySet Name="Order_Details" EntityType="Microsoft.OData.Service.Sample.Northwind.Models.Order_Detail">
           <NavigationPropertyBinding Path="Order" Target="Orders" />
@@ -240,10 +231,22 @@
           <NavigationPropertyBinding Path="Order_Details" Target="Order_Details" />
           <NavigationPropertyBinding Path="Shipper" Target="Shippers" />
         </EntitySet>
-        <EntitySet Name="Products" EntityType="Microsoft.OData.Service.Sample.Northwind.Models.Product">
-          <NavigationPropertyBinding Path="Category" Target="Categories" />
-          <NavigationPropertyBinding Path="Order_Details" Target="Order_Details" />
-          <NavigationPropertyBinding Path="Supplier" Target="Suppliers" />
+        <EntitySet Name="Customers" EntityType="Microsoft.OData.Service.Sample.Northwind.Models.Customer">
+          <NavigationPropertyBinding Path="Orders" Target="Orders" />
+          <NavigationPropertyBinding Path="CustomerDemographics" Target="CustomerDemographics" />
+        </EntitySet>
+        <EntitySet Name="CustomerDemographics" EntityType="Microsoft.OData.Service.Sample.Northwind.Models.CustomerDemographic">
+          <NavigationPropertyBinding Path="Customers" Target="Customers" />
+        </EntitySet>
+        <EntitySet Name="Employees" EntityType="Microsoft.OData.Service.Sample.Northwind.Models.Employee">
+          <NavigationPropertyBinding Path="Employees1" Target="Employees" />
+          <NavigationPropertyBinding Path="Employee1" Target="Employees" />
+          <NavigationPropertyBinding Path="Orders" Target="Orders" />
+          <NavigationPropertyBinding Path="Territories" Target="Territories" />
+        </EntitySet>
+        <EntitySet Name="Territories" EntityType="Microsoft.OData.Service.Sample.Northwind.Models.Territory">
+          <NavigationPropertyBinding Path="Region" Target="Regions" />
+          <NavigationPropertyBinding Path="Employees" Target="Employees" />
         </EntitySet>
         <EntitySet Name="Regions" EntityType="Microsoft.OData.Service.Sample.Northwind.Models.Region">
           <NavigationPropertyBinding Path="Territories" Target="Territories" />
@@ -254,10 +257,7 @@
         <EntitySet Name="Suppliers" EntityType="Microsoft.OData.Service.Sample.Northwind.Models.Supplier">
           <NavigationPropertyBinding Path="Products" Target="Products" />
         </EntitySet>
-        <EntitySet Name="Territories" EntityType="Microsoft.OData.Service.Sample.Northwind.Models.Territory">
-          <NavigationPropertyBinding Path="Region" Target="Regions" />
-          <NavigationPropertyBinding Path="Employees" Target="Employees" />
-        </EntitySet>
+        <EntitySet Name="Contacts" EntityType="Microsoft.OData.Service.Sample.Northwind.Models.Contact" />
         <EntitySet Name="ExpensiveProducts" EntityType="Microsoft.OData.Service.Sample.Northwind.Models.Product">
           <NavigationPropertyBinding Path="Category" Target="Categories" />
           <NavigationPropertyBinding Path="Order_Details" Target="Order_Details" />

--- a/test/ODataEndToEnd/Microsoft.OData.Service.Sample.Northwind/Models/NorthwindApi.cs
+++ b/test/ODataEndToEnd/Microsoft.OData.Service.Sample.Northwind/Models/NorthwindApi.cs
@@ -126,7 +126,7 @@ namespace Microsoft.OData.Service.Sample.Northwind.Models
                 // EF Model builder does not build model any more but just entity set name and entity type map
                 if (model == null)
                 {
-                    var collection = context.EntitySetTypeMapCollection;
+                    var collection = context.EntitySetTypeMapDictionary;
                     if (collection == null || collection.Count == 0)
                     {
                         return null;
@@ -149,7 +149,7 @@ namespace Microsoft.OData.Service.Sample.Northwind.Models
                     }
 
                     // Clear the map collection to make RESTier model builder will not build the model again.
-                    context.EntitySetTypeMapCollection.Clear();
+                    collection.Clear();
                     model = builder.GetEdmModel();
                 }
 

--- a/test/ODataEndToEnd/Microsoft.OData.Service.Sample.Trippin/Models/Airline.cs
+++ b/test/ODataEndToEnd/Microsoft.OData.Service.Sample.Trippin/Models/Airline.cs
@@ -8,7 +8,6 @@ namespace Microsoft.OData.Service.Sample.Trippin.Models
 {
     public class Airline
     {
-        [Key]
         public string AirlineCode { get; set; }
 
         public string Name { get; set; }

--- a/test/ODataEndToEnd/Microsoft.OData.Service.Sample.Trippin/Models/TrippinModel.cs
+++ b/test/ODataEndToEnd/Microsoft.OData.Service.Sample.Trippin/Models/TrippinModel.cs
@@ -22,6 +22,8 @@ namespace Microsoft.OData.Service.Sample.Trippin.Models
 
         protected override void OnModelCreating(DbModelBuilder modelBuilder)
         {
+            modelBuilder.Entity<Airline>().HasKey(a =>a.AirlineCode);
+
             modelBuilder.Entity<Trip>().HasMany<Flight>(s => s.Flights).WithMany().Map(c =>
             {
                 c.MapLeftKey("TripId");


### PR DESCRIPTION
### Issues
*This pull request fixes issue #413 .*  

### Description
In Restier 0.5, the model building uses Web APi OData conversion model builder which finds keys of entity type based on ,
a. Whether there is any proeprty marked with key attribute.
b. Whether there is property with name ID or entitytypeNameID
But if the entity type does not define key in this way, then model build will fail

This issue retrieves keys from entity framework and set to model builder.

### Checklist (Uncheck if it is not completed)
- [ x ] Test cases added
- [ x ] Build and test with one-click build and test script passed

