### PR TITLE
Make the OData Extensions public

### DIFF
--- a/src/Microsoft.Restier.Publishers.OData/Extensions.cs
+++ b/src/Microsoft.Restier.Publishers.OData/Extensions.cs
@@ -18,7 +18,7 @@ using Microsoft.Restier.Publishers.OData.Model;
 
 namespace Microsoft.Restier.Publishers.OData
 {
-    internal static class Extensions
+    public static class Extensions
     {
         private const string PropertyNameOfConcurrencyProperties = "ConcurrencyProperties";
 

--- a/src/Microsoft.Restier.Publishers.OData/Model/PropertyAttributes.cs
+++ b/src/Microsoft.Restier.Publishers.OData/Model/PropertyAttributes.cs
@@ -6,7 +6,7 @@ using System;
 namespace Microsoft.Restier.Publishers.OData
 {
     [Flags]
-    internal enum PropertyAttributes
+    public enum PropertyAttributes
     {
         /// <summary>
         /// No flag is set for the property


### PR DESCRIPTION
### Issues
There is no issue open for this request,

### Description
There are situations where this code is useful, for example when having to override some of the built-in behavior to do custom batching. Being able to access extensions like `GetClrType()` is incredibly useful, and making it public would minimize the possibility of duplicate code across codebases.

Also, the team should consider refactoring some of these helpers to live back in the foundational OData classes.

### Checklist (Uncheck if it is not completed)
- [   ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary
- None AFAIK

