### PR TITLE
Convert DateTimeOffset to DateTime when necessary

### DIFF
--- a/src/Microsoft.Restier.AspNet/Query/RestierQueryBuilder.cs
+++ b/src/Microsoft.Restier.AspNet/Query/RestierQueryBuilder.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Restier.AspNet.Query
         {
             var property = Expression.Property(parameterExpression, propertyName);
             var constant = Expression.Constant(
-                Convert.ChangeType(propertyValue, property.Type, CultureInfo.InvariantCulture));
+                TypeConverter.ChangeType(propertyValue, property.Type, CultureInfo.InvariantCulture));
             return Expression.Equal(property, constant);
         }
 

--- a/src/Microsoft.Restier.Core/Extensions/TypeExtensions.cs
+++ b/src/Microsoft.Restier.Core/Extensions/TypeExtensions.cs
@@ -129,4 +129,16 @@ namespace System
             return underlyingTypeOrSelf == typeof(DateTimeOffset);
         }
     }
+
+    internal static class TypeConverter
+    {
+        public static object ChangeType(object value, Type conversionType, IFormatProvider provider)
+        {
+            if (conversionType == typeof(DateTime) && value is DateTimeOffset)
+            {
+                return ((DateTimeOffset)value).DateTime;
+            }
+            return Convert.ChangeType(value, conversionType, provider);
+        }
+    }
 }

--- a/src/Microsoft.Restier.Core/Submit/ChangeSetItem.cs
+++ b/src/Microsoft.Restier.Core/Submit/ChangeSetItem.cs
@@ -305,7 +305,7 @@ namespace Microsoft.Restier.Core.Submit
 
             if (itemValue.GetType() != property.Type)
             {
-                itemValue = Convert.ChangeType(itemValue, property.Type, CultureInfo.InvariantCulture);
+                itemValue = TypeConverter.ChangeType(itemValue, property.Type, CultureInfo.InvariantCulture);
             }
 
             // TODO GitHubIssue#31 : Check if LinqParameterContainer is necessary


### PR DESCRIPTION
### Issues
This pull request fixes issue #578.

### Description
Entities with a `DateTime` property in their key can't be created/read/updated/deleted because OData Web API does not support `DateTime` in the keys. This pull request addresses this issue by converting `DateTimeOffset` to `DateTime` when necessary.

### Checklist
- [ ] Test cases added
- [ ] Build and test with one-click build and test script passed

### Additional work necessary
No additional work necessary.
