### PR TITLE
Enabling code analysis for RESTier

### DIFF
--- a/src/GlobalSuppressions.cs
+++ b/src/GlobalSuppressions.cs
@@ -186,10 +186,20 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.Core.ConventionBasedChangeSetItemValidator")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.Core.PropertyBag")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.Providers.EntityFramework.ModelProducer")]
+[assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.Providers.EntityFramework.QueryExecutor")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.Providers.EntityFramework.QueryExpressionProcessor")]
+[assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.Providers.EntityFramework.SubmitExecutor")]
+[assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.Publishers.OData.Model.RestierModelBuilder")]
+[assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.Publishers.OData.Model.RestierModelExtender+ModelBuilder")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.Publishers.OData.Model.RestierModelExtender+QueryExpressionExpander")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.Publishers.OData.Model.RestierModelExtender+QueryExpressionSourcer")]
+[assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.Publishers.OData.Operation.OperationExecutor")]
+[assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.Publishers.OData.Query.RestierQueryExecutor")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Scope = "type", Target = "Microsoft.Restier.Publishers.OData.Query.RestierQueryExecutorOptions")]
+#endregion
+
+#region CA1822 Mark members as static
+[assembly: SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Scope = "member", Target = "Microsoft.Restier.Publishers.OData.Batch.RestierBatchChangeSetRequestItem.#SubmitChangeSet(System.Net.Http.HttpRequestMessage,Microsoft.Restier.Core.Submit.ChangeSet)")]
 #endregion
 
 #endregion

--- a/src/Microsoft.Restier.Core/Microsoft.Restier.Core.csproj
+++ b/src/Microsoft.Restier.Core/Microsoft.Restier.Core.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Microsoft.Restier.Core</RootNamespace>
     <AssemblyName>Microsoft.Restier.Core</AssemblyName>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
-    <RunCodeAnalysis>$(CodeAnalysis)</RunCodeAnalysis>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\Strict.ruleset</CodeAnalysisRuleSet>
     <!-- TODO: compile as a portable assembly -->
   </PropertyGroup>

--- a/src/Microsoft.Restier.Core/Microsoft.Restier.Core.csproj
+++ b/src/Microsoft.Restier.Core/Microsoft.Restier.Core.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Microsoft.Restier.Core</RootNamespace>
     <AssemblyName>Microsoft.Restier.Core</AssemblyName>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <RunCodeAnalysis Condition=" '$(RunCodeAnalysis)' == '' ">true</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\Strict.ruleset</CodeAnalysisRuleSet>
     <!-- TODO: compile as a portable assembly -->
   </PropertyGroup>

--- a/src/Microsoft.Restier.Core/Submit/DefaultSubmitHandler.cs
+++ b/src/Microsoft.Restier.Core/Submit/DefaultSubmitHandler.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Restier.Core.Submit
 
             await PerformPreEvent(context, currentChangeSetItems, cancellationToken);
 
-            await PerformPersist(context, currentChangeSetItems, cancellationToken);
+            await PerformPersist(context, cancellationToken);
 
             context.ChangeSet.Entries.Clear();
 
@@ -210,7 +210,6 @@ namespace Microsoft.Restier.Core.Submit
 
         private static async Task PerformPersist(
             SubmitContext context,
-            IEnumerable<ChangeSetItem> changeSetItems,
             CancellationToken cancellationToken)
         {
             var executor = context.GetApiService<ISubmitExecutor>();

--- a/src/Microsoft.Restier.Providers.EntityFramework/Microsoft.Restier.Providers.EntityFramework.csproj
+++ b/src/Microsoft.Restier.Providers.EntityFramework/Microsoft.Restier.Providers.EntityFramework.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Microsoft.Restier.Providers.EntityFramework</RootNamespace>
     <AssemblyName>Microsoft.Restier.Providers.EntityFramework</AssemblyName>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <RunCodeAnalysis Condition=" '$(RunCodeAnalysis)' == '' ">true</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\Strict.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Microsoft.Restier.Providers.EntityFramework/Microsoft.Restier.Providers.EntityFramework.csproj
+++ b/src/Microsoft.Restier.Providers.EntityFramework/Microsoft.Restier.Providers.EntityFramework.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Microsoft.Restier.Providers.EntityFramework</RootNamespace>
     <AssemblyName>Microsoft.Restier.Providers.EntityFramework</AssemblyName>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
-    <RunCodeAnalysis>$(CodeAnalysis)</RunCodeAnalysis>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\Strict.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Microsoft.Restier.Publishers.OData/Microsoft.Restier.Publishers.OData.csproj
+++ b/src/Microsoft.Restier.Publishers.OData/Microsoft.Restier.Publishers.OData.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Microsoft.Restier.Publishers.OData</RootNamespace>
     <AssemblyName>Microsoft.Restier.Publishers.OData</AssemblyName>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
-    <RunCodeAnalysis>$(CodeAnalysis)</RunCodeAnalysis>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\Strict.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Microsoft.Restier.Publishers.OData/Microsoft.Restier.Publishers.OData.csproj
+++ b/src/Microsoft.Restier.Publishers.OData/Microsoft.Restier.Publishers.OData.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Microsoft.Restier.Publishers.OData</RootNamespace>
     <AssemblyName>Microsoft.Restier.Publishers.OData</AssemblyName>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <RunCodeAnalysis Condition=" '$(RunCodeAnalysis)' == '' ">true</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\Strict.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
- Enabling code analysis during builds by default
- Fixing error regarding unused parameter by removing unused parameter
- Suppressing errors regarding un-instantiated classes because they are actually being referenced and will be utilized during runtime per service call
- Suppressing error regarding marking function as static as the function neither resides in a utility class, nor is appropriate to be static
