### PR TITLE
Reverted to one ServicesCollection again

### DIFF
--- a/src/Microsoft.Restier.AspNet/Extensions/HttpConfigurationExtensions.cs
+++ b/src/Microsoft.Restier.AspNet/Extensions/HttpConfigurationExtensions.cs
@@ -20,7 +20,6 @@ namespace System.Web.Http
     /// </summary>
     public static class HttpConfigurationExtensions
     {
-
         /// <summary>
         /// 
         /// </summary>
@@ -30,30 +29,17 @@ namespace System.Web.Http
         /// <returns></returns>
         public static HttpConfiguration UseRestier<TApi>(this HttpConfiguration config, Action<IServiceCollection> configureAction) where TApi : ApiBase
         {
-            return UseRestier<TApi>(config, null, configureAction);
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <typeparam name="TApi"></typeparam>
-        /// <param name="config"></param>
-        /// <param name="preOdataConfigureAction"></param>
-        /// <param name="postOdataConfigureAction"></param>
-        /// <returns></returns>
-        public static HttpConfiguration UseRestier<TApi>(this HttpConfiguration config, Action<IServiceCollection> preOdataConfigureAction, Action<IServiceCollection> postOdataConfigureAction) where TApi : ApiBase
-        {
             config.UseCustomContainerBuilder(() =>
             {
-                var builder = new RestierContainerBuilder(typeof(TApi), preOdataConfigureAction, (services) =>
+                var builder = new RestierContainerBuilder(typeof(TApi), (services) =>
                 {
                     services
-                   .AddCoreServices(typeof(TApi))
-                   .AddConventionBasedServices(typeof(TApi));
+                   .AddRestierCoreServices(typeof(TApi))
+                   .AddRestierConventionBasedServices(typeof(TApi));
 
-                    postOdataConfigureAction(services);
+                    configureAction(services);
 
-                    services.AddRestierServices<TApi>();
+                    services.AddRestierDefaultServices<TApi>();
                 });
 
                 return builder;

--- a/src/Microsoft.Restier.AspNet/Extensions/HttpConfigurationExtensions.cs
+++ b/src/Microsoft.Restier.AspNet/Extensions/HttpConfigurationExtensions.cs
@@ -32,14 +32,17 @@ namespace System.Web.Http
         {
             config.UseCustomContainerBuilder(() =>
             {
-                var builder = new RestierContainerBuilder(typeof(TApi));
-                builder.RestierServices
-                    .AddCoreServices(typeof(TApi))
-                    .AddConventionBasedServices(typeof(TApi));
+                var builder = new RestierContainerBuilder(typeof(TApi), null, (services) =>
+                {
+                    services
+                   .AddCoreServices(typeof(TApi))
+                   .AddConventionBasedServices(typeof(TApi));
 
-                configureAction(builder.RestierServices);
+                    configureAction(services);
 
-                builder.RestierServices.AddRestierServices<TApi>();
+                    services.AddRestierServices<TApi>();
+                });
+               
                 return builder;
             });
 

--- a/src/Microsoft.Restier.AspNet/Extensions/HttpConfigurationExtensions.cs
+++ b/src/Microsoft.Restier.AspNet/Extensions/HttpConfigurationExtensions.cs
@@ -30,19 +30,32 @@ namespace System.Web.Http
         /// <returns></returns>
         public static HttpConfiguration UseRestier<TApi>(this HttpConfiguration config, Action<IServiceCollection> configureAction) where TApi : ApiBase
         {
+            return UseRestier<TApi>(config, null, configureAction);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <typeparam name="TApi"></typeparam>
+        /// <param name="config"></param>
+        /// <param name="preOdataConfigureAction"></param>
+        /// <param name="postOdataConfigureAction"></param>
+        /// <returns></returns>
+        public static HttpConfiguration UseRestier<TApi>(this HttpConfiguration config, Action<IServiceCollection> preOdataConfigureAction, Action<IServiceCollection> postOdataConfigureAction) where TApi : ApiBase
+        {
             config.UseCustomContainerBuilder(() =>
             {
-                var builder = new RestierContainerBuilder(typeof(TApi), null, (services) =>
+                var builder = new RestierContainerBuilder(typeof(TApi), preOdataConfigureAction, (services) =>
                 {
                     services
                    .AddCoreServices(typeof(TApi))
                    .AddConventionBasedServices(typeof(TApi));
 
-                    configureAction(services);
+                    postOdataConfigureAction(services);
 
                     services.AddRestierServices<TApi>();
                 });
-               
+
                 return builder;
             });
 

--- a/src/Microsoft.Restier.AspNet/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Restier.AspNet/Extensions/ServiceCollectionExtensions.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Restier.AspNet
         /// <typeparam name="T">The Api type.</typeparam>
         /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <returns>Current <see cref="IServiceCollection"/></returns>
-        public static IServiceCollection AddRestierServices<T>(this IServiceCollection services)
+        public static IServiceCollection AddRestierDefaultServices<T>(this IServiceCollection services)
         {
             if (services.HasService<RestierQueryExecutor>())
             {
@@ -46,14 +46,11 @@ namespace Microsoft.Restier.AspNet
             AddRestierModelExtender(services, typeof(T));
             AddOperationModelBuilder(services, typeof(T));
 
-            // Add OData Query Settings and validation settings
-            Func<IServiceProvider, ODataQuerySettings> querySettingFactory = (sp) => new ODataQuerySettings
+            services.AddSingleton(new ODataQuerySettings
             {
                 HandleNullPropagation = HandleNullPropagationOption.False,
                 PageSize = null,  // no support for server enforced PageSize, yet
-            };
-
-            services.AddSingleton(typeof(ODataQuerySettings), querySettingFactory);
+            });
             services.AddSingleton<ODataValidationSettings>();
 
             // Make serializer and deserializer provider as DI services

--- a/src/Microsoft.Restier.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Restier.Core/Extensions/ServiceCollectionExtensions.cs
@@ -210,7 +210,7 @@ namespace Microsoft.Restier.Core
         /// The type of a class on which code-based conventions are used.
         /// </param>
         /// <returns>Current <see cref="IServiceCollection"/></returns>
-        public static IServiceCollection AddCoreServices(this IServiceCollection services, Type apiType)
+        public static IServiceCollection AddRestierCoreServices(this IServiceCollection services, Type apiType)
         {
             Ensure.NotNull(services, nameof(services));
             Ensure.NotNull(apiType, nameof(apiType));
@@ -234,7 +234,7 @@ namespace Microsoft.Restier.Core
         /// The type of a class on which code-based conventions are used.
         /// </param>
         /// <returns>Current <see cref="IServiceCollection"/></returns>
-        public static IServiceCollection AddConventionBasedServices(this IServiceCollection services, Type apiType)
+        public static IServiceCollection AddRestierConventionBasedServices(this IServiceCollection services, Type apiType)
         {
             Ensure.NotNull(services, nameof(services));
             Ensure.NotNull(apiType, nameof(apiType));

--- a/src/Microsoft.Restier.Core/RestierContainerBuilder.cs
+++ b/src/Microsoft.Restier.Core/RestierContainerBuilder.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Restier.Core
 
         private readonly Type apiType;
 
-        private readonly Action<IServiceCollection> postOdataConfigureAction;
+        private readonly Action<IServiceCollection> configureAction;
 
         #endregion
 
@@ -43,17 +43,14 @@ namespace Microsoft.Restier.Core
         /// Initializes a new instance of the <see cref="RestierContainerBuilder" /> class.
         /// </summary>
         /// <param name="apiType">The Api Type</param>
-        /// <param name="preOdataConfigureAction">Action to register services Pre OData service registration.</param>
-        /// <param name="postOdataConfigureAction">Action to register services post OData service registration.</param>
+        /// <param name="configureAction">Action to register services post OData service registration.</param>
         public RestierContainerBuilder(
             Type apiType, 
-            Action<IServiceCollection> preOdataConfigureAction = null, 
-            Action<IServiceCollection> postOdataConfigureAction = null)
+            Action<IServiceCollection> configureAction = null)
         {
             this.apiType = apiType;
-            this.postOdataConfigureAction = postOdataConfigureAction;
+            this.configureAction = configureAction;
             Services = new ServiceCollection();
-            preOdataConfigureAction?.Invoke(Services);
         }
 
         #endregion
@@ -115,7 +112,7 @@ namespace Microsoft.Restier.Core
         /// <returns>The container built by this builder.</returns>
         public virtual IServiceProvider BuildContainer()
         {
-            postOdataConfigureAction?.Invoke(Services);
+            configureAction?.Invoke(Services);
             AddRestierService(!Services.Any(x => x.ServiceType == typeof(ApiBase)));
             return Services.BuildServiceProvider();
         }

--- a/src/Microsoft.Restier.Samples.Northwind.AspNet/App_Start/WebApiConfig.cs
+++ b/src/Microsoft.Restier.Samples.Northwind.AspNet/App_Start/WebApiConfig.cs
@@ -3,6 +3,7 @@ using System.Web.Http;
 using Microsoft.AspNet.OData.Extensions;
 using Microsoft.AspNet.OData.Query;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Restier.AspNet;
 using Microsoft.Restier.EntityFramework;
 using Microsoft.Restier.Samples.Northwind.AspNet.Controllers;
 using Microsoft.Restier.Samples.Northwind.AspNet.Data;
@@ -29,11 +30,23 @@ namespace Microsoft.Restier.Samples.Northwind.AspNet
 
             config.MapHttpAttributeRoutes();
 
-            config.UseRestier<NorthwindApi>((services) =>
+            config.UseRestier<NorthwindApi>(
+            (services) =>
             {
+                // This delegate is executed before OData is added to the container.
+                // This delegate is optional. 
                 services.AddEF6ProviderServices<NorthwindEntities>();
+            },
+            (services) =>
+            {
+                // This delegate is executed after OData is added to the container.
+                // Add you replacement services here.
 
-                // RWM: Add you replacement services here.
+                // or even add the RestierServices explicitly yourself to be able to register services after
+                // Restier registration.
+
+                // services.AddRestierServices<NorthwindApi>();
+
                 services.AddSingleton(new ODataValidationSettings
                 {
                     MaxAnyAllExpressionDepth = 3,

--- a/src/Microsoft.Restier.Samples.Northwind.AspNet/App_Start/WebApiConfig.cs
+++ b/src/Microsoft.Restier.Samples.Northwind.AspNet/App_Start/WebApiConfig.cs
@@ -33,19 +33,9 @@ namespace Microsoft.Restier.Samples.Northwind.AspNet
             config.UseRestier<NorthwindApi>(
             (services) =>
             {
-                // This delegate is executed before OData is added to the container.
-                // This delegate is optional. 
-                services.AddEF6ProviderServices<NorthwindEntities>();
-            },
-            (services) =>
-            {
                 // This delegate is executed after OData is added to the container.
                 // Add you replacement services here.
-
-                // or even add the RestierServices explicitly yourself to be able to register services after
-                // Restier registration.
-
-                // services.AddRestierServices<NorthwindApi>();
+                services.AddEF6ProviderServices<NorthwindEntities>();
 
                 services.AddSingleton(new ODataValidationSettings
                 {

--- a/src/Microsoft.Restier.Tests.Core/ConventionBasedMethodNameFactoryTests.cs
+++ b/src/Microsoft.Restier.Tests.Core/ConventionBasedMethodNameFactoryTests.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Restier.Tests.Core
         public void ConventionBasedMethodNameFactory_ExecuteMethod_Authorize()
         {
             var container = new RestierContainerBuilder(typeof(TestApi));
-            container.Services.AddCoreServices(typeof(TestApi)).AddConventionBasedServices(typeof(TestApi)).AddTestStoreApiServices();
+            container.Services.AddRestierCoreServices(typeof(TestApi)).AddRestierConventionBasedServices(typeof(TestApi)).AddTestStoreApiServices();
             var provider = container.BuildContainer();
             var api = provider.GetService<TestApi>();
 
@@ -109,7 +109,7 @@ namespace Microsoft.Restier.Tests.Core
         public void ConventionBasedMethodNameFactory_ExecuteMethod_PreSubmit()
         {
             var container = new RestierContainerBuilder(typeof(TestApi));
-            container.Services.AddCoreServices(typeof(TestApi)).AddConventionBasedServices(typeof(TestApi)).AddTestStoreApiServices();
+            container.Services.AddRestierCoreServices(typeof(TestApi)).AddRestierConventionBasedServices(typeof(TestApi)).AddTestStoreApiServices();
             var provider = container.BuildContainer();
             var api = provider.GetService<TestApi>();
 
@@ -122,7 +122,7 @@ namespace Microsoft.Restier.Tests.Core
         public void ConventionBasedMethodNameFactory_ExecuteMethod_Submit()
         {
             var container = new RestierContainerBuilder(typeof(TestApi));
-            container.Services.AddCoreServices(typeof(TestApi)).AddConventionBasedServices(typeof(TestApi)).AddTestStoreApiServices();
+            container.Services.AddRestierCoreServices(typeof(TestApi)).AddRestierConventionBasedServices(typeof(TestApi)).AddTestStoreApiServices();
             var provider = container.BuildContainer();
             var api = provider.GetService<TestApi>();
 
@@ -135,7 +135,7 @@ namespace Microsoft.Restier.Tests.Core
         public void ConventionBasedMethodNameFactory_ExecuteMethod_PostSubmit()
         {
             var container = new RestierContainerBuilder(typeof(TestApi));
-            container.Services.AddCoreServices(typeof(TestApi)).AddConventionBasedServices(typeof(TestApi)).AddTestStoreApiServices();
+            container.Services.AddRestierCoreServices(typeof(TestApi)).AddRestierConventionBasedServices(typeof(TestApi)).AddTestStoreApiServices();
             var provider = container.BuildContainer();
             var api = provider.GetService<TestApi>();
 

--- a/src/Microsoft.Restier.Tests.Core/ConventionBasedMethodNameFactoryTests.cs
+++ b/src/Microsoft.Restier.Tests.Core/ConventionBasedMethodNameFactoryTests.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Restier.Tests.Core
         public void ConventionBasedMethodNameFactory_ExecuteMethod_Authorize()
         {
             var container = new RestierContainerBuilder(typeof(TestApi));
-            container.RestierServices.AddCoreServices(typeof(TestApi)).AddConventionBasedServices(typeof(TestApi)).AddTestStoreApiServices();
+            container.Services.AddCoreServices(typeof(TestApi)).AddConventionBasedServices(typeof(TestApi)).AddTestStoreApiServices();
             var provider = container.BuildContainer();
             var api = provider.GetService<TestApi>();
 
@@ -109,7 +109,7 @@ namespace Microsoft.Restier.Tests.Core
         public void ConventionBasedMethodNameFactory_ExecuteMethod_PreSubmit()
         {
             var container = new RestierContainerBuilder(typeof(TestApi));
-            container.RestierServices.AddCoreServices(typeof(TestApi)).AddConventionBasedServices(typeof(TestApi)).AddTestStoreApiServices();
+            container.Services.AddCoreServices(typeof(TestApi)).AddConventionBasedServices(typeof(TestApi)).AddTestStoreApiServices();
             var provider = container.BuildContainer();
             var api = provider.GetService<TestApi>();
 
@@ -122,7 +122,7 @@ namespace Microsoft.Restier.Tests.Core
         public void ConventionBasedMethodNameFactory_ExecuteMethod_Submit()
         {
             var container = new RestierContainerBuilder(typeof(TestApi));
-            container.RestierServices.AddCoreServices(typeof(TestApi)).AddConventionBasedServices(typeof(TestApi)).AddTestStoreApiServices();
+            container.Services.AddCoreServices(typeof(TestApi)).AddConventionBasedServices(typeof(TestApi)).AddTestStoreApiServices();
             var provider = container.BuildContainer();
             var api = provider.GetService<TestApi>();
 
@@ -135,7 +135,7 @@ namespace Microsoft.Restier.Tests.Core
         public void ConventionBasedMethodNameFactory_ExecuteMethod_PostSubmit()
         {
             var container = new RestierContainerBuilder(typeof(TestApi));
-            container.RestierServices.AddCoreServices(typeof(TestApi)).AddConventionBasedServices(typeof(TestApi)).AddTestStoreApiServices();
+            container.Services.AddCoreServices(typeof(TestApi)).AddConventionBasedServices(typeof(TestApi)).AddTestStoreApiServices();
             var provider = container.BuildContainer();
             var api = provider.GetService<TestApi>();
 

--- a/src/Microsoft.Restier.Tests.Core/InvocationContextTests.cs
+++ b/src/Microsoft.Restier.Tests.Core/InvocationContextTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Restier.Tests.Core
         public void InvocationContext_GetsApiServicesCorrectly()
         {
             var container = new RestierContainerBuilder(typeof(TestApi));
-            container.RestierServices.AddCoreServices(typeof(TestApi))
+            container.Services.AddCoreServices(typeof(TestApi))
                 .AddConventionBasedServices(typeof(TestApi))
                 .AddTestStoreApiServices()
                 .AddService<IServiceA>((sp, next) => TestApi.ApiService);

--- a/src/Microsoft.Restier.Tests.Core/InvocationContextTests.cs
+++ b/src/Microsoft.Restier.Tests.Core/InvocationContextTests.cs
@@ -21,8 +21,8 @@ namespace Microsoft.Restier.Tests.Core
         public void InvocationContext_GetsApiServicesCorrectly()
         {
             var container = new RestierContainerBuilder(typeof(TestApi));
-            container.Services.AddCoreServices(typeof(TestApi))
-                .AddConventionBasedServices(typeof(TestApi))
+            container.Services.AddRestierCoreServices(typeof(TestApi))
+                .AddRestierConventionBasedServices(typeof(TestApi))
                 .AddTestStoreApiServices()
                 .AddService<IServiceA>((sp, next) => TestApi.ApiService);
             var provider = container.BuildContainer();

--- a/src/Microsoft.Restier.Tests.Core/Model/DefaultModelHandlerTests.cs
+++ b/src/Microsoft.Restier.Tests.Core/Model/DefaultModelHandlerTests.cs
@@ -64,9 +64,9 @@ namespace Microsoft.Restier.Tests.Core.Model
                 for (var i = 0; i < 2; i++)
                 {
                     var container = new RestierContainerBuilder(typeof(TestableEmptyApi));
-                    container.RestierServices.AddCoreServices(typeof(TestableEmptyApi))
+                    container.Services.AddCoreServices(typeof(TestableEmptyApi))
                         .AddService<IModelBuilder>((sp, next) => new TestSingleCallModelBuilder());
-                    addTestServices(container.RestierServices);
+                    addTestServices(container.Services);
 
                     var provider = container.BuildContainer();
                     var tasks = PrepareThreads(50, provider, wait);
@@ -84,9 +84,9 @@ namespace Microsoft.Restier.Tests.Core.Model
             using (var wait = new ManualResetEventSlim(false))
             {
                 var container = new RestierContainerBuilder(typeof(TestableEmptyApi));
-                container.RestierServices.AddCoreServices(typeof(TestableEmptyApi))
+                container.Services.AddCoreServices(typeof(TestableEmptyApi))
                     .AddService<IModelBuilder>((sp, next) => new TestRetryModelBuilder());
-                addTestServices(container.RestierServices);
+                addTestServices(container.Services);
 
                 var provider = container.BuildContainer();
 

--- a/src/Microsoft.Restier.Tests.Core/Model/DefaultModelHandlerTests.cs
+++ b/src/Microsoft.Restier.Tests.Core/Model/DefaultModelHandlerTests.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Restier.Tests.Core.Model
                 for (var i = 0; i < 2; i++)
                 {
                     var container = new RestierContainerBuilder(typeof(TestableEmptyApi));
-                    container.Services.AddCoreServices(typeof(TestableEmptyApi))
+                    container.Services.AddRestierCoreServices(typeof(TestableEmptyApi))
                         .AddService<IModelBuilder>((sp, next) => new TestSingleCallModelBuilder());
                     addTestServices(container.Services);
 
@@ -84,7 +84,7 @@ namespace Microsoft.Restier.Tests.Core.Model
             using (var wait = new ManualResetEventSlim(false))
             {
                 var container = new RestierContainerBuilder(typeof(TestableEmptyApi));
-                container.Services.AddCoreServices(typeof(TestableEmptyApi))
+                container.Services.AddRestierCoreServices(typeof(TestableEmptyApi))
                     .AddService<IModelBuilder>((sp, next) => new TestRetryModelBuilder());
                 addTestServices(container.Services);
 

--- a/src/Microsoft.Restier.Tests.Core/PropertyBagTests.cs
+++ b/src/Microsoft.Restier.Tests.Core/PropertyBagTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Restier.Tests.Core
         public void PropertyBag_ManipulatesPropertiesCorrectly()
         {
             var container = new RestierContainerBuilder(typeof(TestableEmptyApi));
-            container.RestierServices
+            container.Services
                 .AddCoreServices(typeof(TestableEmptyApi))
                 .AddConventionBasedServices(typeof(TestableEmptyApi))
                 .AddTestStoreApiServices()
@@ -59,7 +59,7 @@ namespace Microsoft.Restier.Tests.Core
         public void PropertyBagsAreDisposedCorrectly()
         {
             var container = new RestierContainerBuilder(typeof(TestableEmptyApi));
-            container.RestierServices
+            container.Services
                 .AddCoreServices(typeof(TestableEmptyApi))
                 .AddConventionBasedServices(typeof(TestableEmptyApi))
                 .AddTestStoreApiServices()

--- a/src/Microsoft.Restier.Tests.Core/PropertyBagTests.cs
+++ b/src/Microsoft.Restier.Tests.Core/PropertyBagTests.cs
@@ -22,8 +22,8 @@ namespace Microsoft.Restier.Tests.Core
         {
             var container = new RestierContainerBuilder(typeof(TestableEmptyApi));
             container.Services
-                .AddCoreServices(typeof(TestableEmptyApi))
-                .AddConventionBasedServices(typeof(TestableEmptyApi))
+                .AddRestierCoreServices(typeof(TestableEmptyApi))
+                .AddRestierConventionBasedServices(typeof(TestableEmptyApi))
                 .AddTestStoreApiServices()
                 .AddScoped<MyPropertyBag>();
             var provider = container.BuildContainer();
@@ -60,8 +60,8 @@ namespace Microsoft.Restier.Tests.Core
         {
             var container = new RestierContainerBuilder(typeof(TestableEmptyApi));
             container.Services
-                .AddCoreServices(typeof(TestableEmptyApi))
-                .AddConventionBasedServices(typeof(TestableEmptyApi))
+                .AddRestierCoreServices(typeof(TestableEmptyApi))
+                .AddRestierConventionBasedServices(typeof(TestableEmptyApi))
                 .AddTestStoreApiServices()
                 .AddScoped<MyPropertyBag>();
 


### PR DESCRIPTION
on the RestierContainerBuilder and added support for pre-odata and post-odata service registration hooks (as constructor arguments).

All unit tests pass.