### PR TITLE
Fix for #698 - .NET6 support for Microsoft.Extensions.DependencyInjection

### DIFF
--- a/src/Microsoft.Restier.Core/Microsoft.Restier.Core.csproj
+++ b/src/Microsoft.Restier.Core/Microsoft.Restier.Core.csproj
@@ -51,7 +51,7 @@
   <ItemGroup>
     <PackageReference Include="Ben.TypeDictionary" Version="0.1.4" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[5.*, 6.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[5.*, 6.*)" />
     <PackageReference Include="Microsoft.OData.Core" Version="[7.*, 8.0.0)" />
     <PackageReference Include="Microsoft.OData.Edm" Version="[7.*, 8.0.0)" />
     <PackageReference Include="Newtonsoft.Json" Version="[10.0.1, 14.0.0)" />


### PR DESCRIPTION
### Issues
This pull request fixes issue #698

### Description
Removed the upper version 
