### PR TITLE
NavigationPropertyTest reliability improvement

### DIFF
--- a/src/Microsoft.Restier.Tests.AspNet/FeatureTests/NavigationPropertyTests.cs
+++ b/src/Microsoft.Restier.Tests.AspNet/FeatureTests/NavigationPropertyTests.cs
@@ -9,6 +9,11 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Restier.Tests.Shared.Scenarios.Library;
+using System;
+using System.Net;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Linq;
 
 #if NETCOREAPP3_1_OR_GREATER
 using CloudNimble.Breakdance.AspNetCore.OData;
@@ -31,16 +36,159 @@ namespace Microsoft.Restier.Tests.AspNet.FeatureTests
     {
 
         [TestMethod]
-        public async Task NavigationProperties_ChildrenShouldFilter()
+        public async Task NavigationProperties_ChildrenShouldFilter_IsActive()
         {
-            var response = await RestierTestHelpers.ExecuteTestRequest<LibraryApi>(HttpMethod.Get, resource: "/Publishers('Publisher1')/Books", serviceCollection: services => services.AddEntityFrameworkServices<LibraryContext>());
-            var content = await TestContext.LogAndReturnMessageContentAsync(response);
+            // set up the context to have the needed records for this test
+            var context = await RestierTestHelpers.GetTestableInjectedService<LibraryApi, LibraryContext>(serviceCollection: (services) => services.AddEntityFrameworkServices<LibraryContext>());
+
+            var publisher1 = new Publisher 
+            { 
+                Id = "navtest-publisher-1", 
+                Books = new System.Collections.ObjectModel.ObservableCollection<Book>
+                {
+                    new Book { Id = Guid.NewGuid(), Title = "navtest-pub1-book-1", IsActive = true },
+                    new Book { Id = Guid.NewGuid(), Title = "navtest-pub1-book-2", IsActive = false }
+                }, 
+                Addr = new Shared.Scenarios.Library.Address { Zip = "12345" } 
+            };
+            context.Publishers.Add(publisher1);
+
+            // save publishers to the context
+            context.SaveChanges();
+
+            // double check that the first publisher has the expected amount of books
+            var request = await RestierTestHelpers.ExecuteTestRequest<LibraryApi>(HttpMethod.Get, resource: $"/Publishers('{publisher1.Id}')?$expand=Books", acceptHeader: ODataConstants.DefaultAcceptHeader, serviceCollection: (services) => services.AddEntityFrameworkServices<LibraryContext>());
+            request.IsSuccessStatusCode.Should().BeTrue();
+            var (publisher, ErrorContent1) = await request.DeserializeResponseAsync<Publisher>();
+            publisher.Should().NotBeNull();
+            publisher.Books.Should().HaveCount(1);
+
+            // query books with the navigation filter
+            var response = await RestierTestHelpers.ExecuteTestRequest<LibraryApi>(HttpMethod.Get, resource: $"/Publishers('{publisher1.Id}')/Books", serviceCollection: services => services.AddEntityFrameworkServices<LibraryContext>());
 
             response.IsSuccessStatusCode.Should().BeTrue();
-            var (Response, ErrorContent) = await response.DeserializeResponseAsync<ODataV4List<Book>>();
-            Response.Items.Should().HaveCount(2);
+            var (books, ErrorContent2) = await response.DeserializeResponseAsync<ODataV4List<Book>>();
+            books.Items.Should().HaveCount(1);
+
+            // clean up the context
+            var removeBooks = publisher1.Books.ToList();
+            foreach (var book in removeBooks)
+            {
+                context.Books.Remove(book);
+            }
+            context.Publishers.Remove(publisher1);
+            context.SaveChanges();
         }
 
+        [TestMethod]
+        public async Task NavigationProperties_ChildrenShouldFilter_Explicit()
+        {
+            // set up the context to have the needed records for this test
+            var context = await RestierTestHelpers.GetTestableInjectedService<LibraryApi, LibraryContext>(serviceCollection: (services) => services.AddEntityFrameworkServices<LibraryContext>());
+
+            var publisher1 = new Publisher
+            {
+                Id = "navtest-publisher-1",
+                Books = new System.Collections.ObjectModel.ObservableCollection<Book>
+                {
+                    new Book { Id = Guid.NewGuid(), Title = "top10-navtest-pub1-book-1", IsActive = true },
+                    new Book { Id = Guid.NewGuid(), Title = "top5-navtest-pub1-book-2", IsActive = true },
+                },
+                Addr = new Shared.Scenarios.Library.Address { Zip = "12345" }
+            };
+            context.Publishers.Add(publisher1);
+
+            // save publishers to the context
+            context.SaveChanges();
+
+            // double check that the first publisher has the expected amount of books
+            var request = await RestierTestHelpers.ExecuteTestRequest<LibraryApi>(HttpMethod.Get, resource: $"/Publishers('{publisher1.Id}')?$expand=Books($filter=startswith(Title, 'top10'))", acceptHeader: ODataConstants.DefaultAcceptHeader, serviceCollection: (services) => services.AddEntityFrameworkServices<LibraryContext>());
+            request.IsSuccessStatusCode.Should().BeTrue();
+            var (publisher, ErrorContent1) = await request.DeserializeResponseAsync<Publisher>();
+            publisher.Should().NotBeNull();
+            publisher.Books.Should().HaveCount(1);
+
+            // query books with the navigation filter
+            var response = await RestierTestHelpers.ExecuteTestRequest<LibraryApi>(HttpMethod.Get, resource: $"/Publishers('{publisher1.Id}')/Books?$filter=startswith(Title, 'top10')", serviceCollection: services => services.AddEntityFrameworkServices<LibraryContext>());
+
+            response.IsSuccessStatusCode.Should().BeTrue();
+            var (bookData, ErrorContent2) = await response.DeserializeResponseAsync<ODataV4List<Book>>();
+            bookData.Items.Should().HaveCount(1);
+
+            // clean up the context
+            var removeBooks = publisher1.Books.ToList();
+            foreach (var book in removeBooks)
+            {
+                context.Books.Remove(book);
+            }
+            context.Publishers.Remove(publisher1);
+            context.SaveChanges();
+        }
+
+        [TestMethod]
+        public async Task NavigationProperties_ChildrenShouldFilter_AcrossProviders()
+        {
+            // set up the context to have the needed records for this test
+            var context = await RestierTestHelpers.GetTestableInjectedService<LibraryApi, LibraryContext>(serviceCollection: (services) => services.AddEntityFrameworkServices<LibraryContext>());
+
+            var publisher1 = new Publisher
+            {
+                Id = "navtest-publisher-1",
+                Books = new System.Collections.ObjectModel.ObservableCollection<Book>
+                {
+                    new Book { Id = Guid.NewGuid(), Title = "navtest-pub1-book-1", IsActive = true },
+                    new Book { Id = Guid.NewGuid(), Title = "navtest-pub1-book-2", IsActive = true },
+                },
+                Addr = new Shared.Scenarios.Library.Address { Zip = "12345" }
+            };
+            context.Publishers.Add(publisher1);
+
+            var publisher2 = new Publisher
+            {
+                Id = "navtest-publisher-2",
+                Books = new System.Collections.ObjectModel.ObservableCollection<Book>
+                {
+                    new Book { Id = Guid.NewGuid(), Title = "navtest-pub2-book-3", IsActive = true },
+                },
+                Addr = new Shared.Scenarios.Library.Address { Zip = "12345" }
+            };
+            context.Publishers.Add(publisher2);
+
+            // save publishers to the context
+            context.SaveChanges();
+
+            // double check that the first publisher has the expected amount of books
+            var request = await RestierTestHelpers.ExecuteTestRequest<LibraryApi>(HttpMethod.Get, resource: $"/Publishers('{publisher1.Id}')?$expand=Books", acceptHeader: ODataConstants.DefaultAcceptHeader, serviceCollection: (services) => services.AddEntityFrameworkServices<LibraryContext>());
+            request.IsSuccessStatusCode.Should().BeTrue();
+            var (publisher, ErrorContent1) = await request.DeserializeResponseAsync<Publisher>();
+            publisher.Should().NotBeNull();
+            publisher.Books.Should().HaveCount(2);
+
+            // query books with the navigation filter
+            var response = await RestierTestHelpers.ExecuteTestRequest<LibraryApi>(HttpMethod.Get, resource: $"/Publishers('{publisher1.Id}')/Books", serviceCollection: services => services.AddEntityFrameworkServices<LibraryContext>());
+
+            response.IsSuccessStatusCode.Should().BeTrue();
+            var (bookData, ErrorContent2) = await response.DeserializeResponseAsync<ODataV4List<Book>>();
+            bookData.Items.Should().HaveCount(2);
+
+            // clean up the context
+            var removeBooks = publisher1.Books.ToList();
+            foreach (var book in removeBooks)
+            {
+                context.Books.Remove(book);
+            }
+            context.Publishers.Remove(publisher1);
+
+            removeBooks = publisher2.Books.ToList();
+            foreach (var book in removeBooks)
+            {
+                context.Books.Remove(book);
+            }
+            context.Publishers.Remove(publisher2);
+
+            context.SaveChanges();
+
+        }
     }
 
 }


### PR DESCRIPTION
Modified NavigationPropertyTests to setup/teardown record state in the DbContext during execution.

#702

### Issues
*This pull request fixes issue #702.*  

### Description
Added records to the context prior to execution to expose the desired test surface.  Removed these records after test run.

### Checklist (Uncheck if it is not completed)
- [x] *Test cases added*  (21 tests passing across different configurations for NavigationPropertyTest class.
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary
** none **
