### PR TITLE
Fix Batch on .NET Core

### DIFF
--- a/src/Microsoft.Restier.AspNet/RestierController.cs
+++ b/src/Microsoft.Restier.AspNet/RestierController.cs
@@ -239,13 +239,13 @@ namespace Microsoft.Restier.AspNet
             if (changeSetProperty is null)
             {
                 var changeSet = new ChangeSet();
-                changeSet.Entries.Add(postItem);
+                changeSet.Entries.Enqueue(postItem);
 
                 var result = await api.SubmitAsync(changeSet, cancellationToken).ConfigureAwait(false);
             }
             else
             {
-                changeSetProperty.ChangeSet.Entries.Add(postItem);
+                changeSetProperty.ChangeSet.Entries.Enqueue(postItem);
 
                 await changeSetProperty.OnChangeSetCompleted().ConfigureAwait(false);
             }
@@ -305,13 +305,13 @@ namespace Microsoft.Restier.AspNet
             if (changeSetProperty is null)
             {
                 var changeSet = new ChangeSet();
-                changeSet.Entries.Add(deleteItem);
+                changeSet.Entries.Enqueue(deleteItem);
 
                 var result = await api.SubmitAsync(changeSet, cancellationToken).ConfigureAwait(false);
             }
             else
             {
-                changeSetProperty.ChangeSet.Entries.Add(deleteItem);
+                changeSetProperty.ChangeSet.Entries.Enqueue(deleteItem);
 
                 await changeSetProperty.OnChangeSetCompleted().ConfigureAwait(false);
             }
@@ -455,14 +455,14 @@ namespace Microsoft.Restier.AspNet
             if (changeSetProperty is null)
             {
                 var changeSet = new ChangeSet();
-                changeSet.Entries.Add(updateItem);
+                changeSet.Entries.Enqueue(updateItem);
 
                 //RWM: Seems like we should be using the result here. For something else.
                 var result = await api.SubmitAsync(changeSet, cancellationToken).ConfigureAwait(false);
             }
             else
             {
-                changeSetProperty.ChangeSet.Entries.Add(updateItem);
+                changeSetProperty.ChangeSet.Entries.Enqueue(updateItem);
 
                 await changeSetProperty.OnChangeSetCompleted().ConfigureAwait(false);
             }

--- a/src/Microsoft.Restier.AspNetCore/RestierController.cs
+++ b/src/Microsoft.Restier.AspNetCore/RestierController.cs
@@ -168,13 +168,13 @@ namespace Microsoft.Restier.AspNetCore
             if (changeSetProperty is null)
             {
                 var changeSet = new ChangeSet();
-                changeSet.Entries.Add(postItem);
+                changeSet.Entries.Enqueue(postItem);
 
                 var result = await api.SubmitAsync(changeSet, cancellationToken).ConfigureAwait(false);
             }
             else
             {
-                changeSetProperty.ChangeSet.Entries.Add(postItem);
+                changeSetProperty.ChangeSet.Entries.Enqueue(postItem);
 
                 await changeSetProperty.OnChangeSetCompleted().ConfigureAwait(false);
             }
@@ -235,13 +235,13 @@ namespace Microsoft.Restier.AspNetCore
             if (changeSetProperty is null)
             {
                 var changeSet = new ChangeSet();
-                changeSet.Entries.Add(deleteItem);
+                changeSet.Entries.Enqueue(deleteItem);
 
                 var result = await api.SubmitAsync(changeSet, cancellationToken).ConfigureAwait(false);
             }
             else
             {
-                changeSetProperty.ChangeSet.Entries.Add(deleteItem);
+                changeSetProperty.ChangeSet.Entries.Enqueue(deleteItem);
 
                 await changeSetProperty.OnChangeSetCompleted().ConfigureAwait(false);
             }
@@ -392,14 +392,14 @@ namespace Microsoft.Restier.AspNetCore
             if (changeSetProperty is null)
             {
                 var changeSet = new ChangeSet();
-                changeSet.Entries.Add(updateItem);
+                changeSet.Entries.Enqueue(updateItem);
 
                 // RWM: Seems like we should be using the result here. For something else.
                 var result = await api.SubmitAsync(changeSet, cancellationToken).ConfigureAwait(false);
             }
             else
             {
-                changeSetProperty.ChangeSet.Entries.Add(updateItem);
+                changeSetProperty.ChangeSet.Entries.Enqueue(updateItem);
 
                 await changeSetProperty.OnChangeSetCompleted().ConfigureAwait(false);
             }

--- a/src/Microsoft.Restier.Breakdance/RestierBreakdanceTestBase.cs
+++ b/src/Microsoft.Restier.Breakdance/RestierBreakdanceTestBase.cs
@@ -75,6 +75,7 @@ namespace Microsoft.Restier.Breakdance
                 ApplicationBuilderAction?.Invoke(builder);
                 builder.UseAuthorization();
                 builder.UseDeveloperExceptionPage();
+                builder.UseODataBatching();
                 builder.UseMvc(routeBuilder =>
                 {
                     routeBuilder

--- a/src/Microsoft.Restier.Core/Submit/ChangeSet.cs
+++ b/src/Microsoft.Restier.Core/Submit/ChangeSet.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 
 namespace Microsoft.Restier.Core.Submit
@@ -10,14 +12,14 @@ namespace Microsoft.Restier.Core.Submit
     /// </summary>
     public class ChangeSet
     {
-        private List<ChangeSetItem> entries;
+        private ConcurrentQueue<ChangeSetItem> entries;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ChangeSet" /> class.
         /// </summary>
         public ChangeSet()
-            : this(null)
         {
+            this.entries = new ConcurrentQueue<ChangeSetItem>();
         }
 
         /// <summary>
@@ -28,24 +30,21 @@ namespace Microsoft.Restier.Core.Submit
         /// </param>
         public ChangeSet(IEnumerable<ChangeSetItem> entries)
         {
-            if (entries is not null)
+            if (entries is null)
             {
-                this.entries = new List<ChangeSetItem>(entries);
+                throw new ArgumentNullException(nameof(entries));
             }
+
+            this.entries = new ConcurrentQueue<ChangeSetItem>(entries);
         }
 
         /// <summary>
         /// Gets the entries in this change set.
         /// </summary>
-        public IList<ChangeSetItem> Entries
+        public ConcurrentQueue<ChangeSetItem> Entries
         {
             get
             {
-                if (entries is null)
-                {
-                    entries = new List<ChangeSetItem>();
-                }
-
                 return entries;
             }
         }

--- a/src/Microsoft.Restier.Core/Submit/DefaultSubmitHandler.cs
+++ b/src/Microsoft.Restier.Core/Submit/DefaultSubmitHandler.cs
@@ -90,8 +90,11 @@ namespace Microsoft.Restier.Core.Submit
 
             await PerformPersist(context, cancellationToken).ConfigureAwait(false);
 
+#if NET472
+            while(context.ChangeSet.Entries.TryDequeue(out _));
+#else
             context.ChangeSet.Entries.Clear();
-
+#endif
             await PerformPostEvent(context, currentChangeSetItems, cancellationToken).ConfigureAwait(false);
 
             return context.Result;

--- a/src/Microsoft.Restier.Tests.AspNet/FeatureTests/BatchTests.cs
+++ b/src/Microsoft.Restier.Tests.AspNet/FeatureTests/BatchTests.cs
@@ -216,7 +216,7 @@ OData-Version: 4.0
 
             var request = new HttpRequestMessage(HttpMethod.Post, $"{httpClient.BaseAddress}/$batch");
             request.Content = new StringContent(jsonBatchRequest);
-            request.Content.Headers.ContentType = MediaTypeWithQualityHeaderValue.Parse("application/json;odata.stream=true");
+            request.Content.Headers.ContentType = MediaTypeWithQualityHeaderValue.Parse("application/json");
 
             var response = httpClient.SendAsync(request).Result;
             var content = await TestContext.LogAndReturnMessageContentAsync(response);
@@ -263,7 +263,11 @@ OData-Version: 4.0
             ]
         }";
 
+#if NETCOREAPP
+        const string jsonBatchResponse = @"{""responses"":[{""id"":""1"",""status"":201,""headers"":{""location"":""http://localhost/api/tests/Books(79874b37-ce46-4f4c-aa74-8e02ce4d8b67)"",""content-type"":""application/json; odata.metadata=minimal; odata.streaming=true"",""odata-version"":""4.0""}, ""body"" :{""@odata.context"":""http://localhost/api/tests/$metadata#Books/$entity"",""Id"":""79874b37-ce46-4f4c-aa74-8e02ce4d8b67"",""Isbn"":""1111111111111"",""Title"":""Batch Test #1"",""IsActive"":true}},{""id"":""2"",""status"":201,""headers"":{""location"":""http://localhost/api/tests/Books(c6b67ec7-badc-45c6-98c7-c76b570ce694)"",""content-type"":""application/json; odata.metadata=minimal; odata.streaming=true"",""odata-version"":""4.0""}, ""body"" :{""@odata.context"":""http://localhost/api/tests/$metadata#Books/$entity"",""Id"":""c6b67ec7-badc-45c6-98c7-c76b570ce694"",""Isbn"":""2222222222222"",""Title"":""Batch Test #2"",""IsActive"":true}}]}";
+#else
         const string jsonBatchResponse = @"{""responses"":[{""id"":""1"",""status"":201,""headers"":{""location"":""http://localhost/api/tests/Books(79874b37-ce46-4f4c-aa74-8e02ce4d8b67)"",""content-type"":""application/json; odata.metadata=minimal"",""odata-version"":""4.0""}, ""body"" :{""@odata.context"":""http://localhost/api/tests/$metadata#Books/$entity"",""Id"":""79874b37-ce46-4f4c-aa74-8e02ce4d8b67"",""Isbn"":""1111111111111"",""Title"":""Batch Test #1"",""IsActive"":true}},{""id"":""2"",""status"":201,""headers"":{""location"":""http://localhost/api/tests/Books(c6b67ec7-badc-45c6-98c7-c76b570ce694)"",""content-type"":""application/json; odata.metadata=minimal"",""odata-version"":""4.0""}, ""body"" :{""@odata.context"":""http://localhost/api/tests/$metadata#Books/$entity"",""Id"":""c6b67ec7-badc-45c6-98c7-c76b570ce694"",""Isbn"":""2222222222222"",""Title"":""Batch Test #2"",""IsActive"":true}}]}";
+#endif
 
         /// <summary>
         /// 

--- a/src/Microsoft.Restier.Tests.Core/ApiBaseTests.cs
+++ b/src/Microsoft.Restier.Tests.Core/ApiBaseTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Restier.Tests.Core
         public async Task CanCallSubmitAsync()
         {
             var changeSet = new ChangeSet();
-            changeSet.Entries.Add(
+            changeSet.Entries.Enqueue(
                 new DataModificationItem(
                     "Tests",
                     typeof(Test),


### PR DESCRIPTION
### Issues
*This pull request fixes issue #709.*  

### Description

Issue #1: Batch requests were failing for .NET Core because .NET Core requires the ODataBatch middleware to be registered (must be before UseMvc). It would be nice to do this automatically, but it wasn't clear where we would have access to the apibuilder in order to add the batch middleware. For now, I added the UseODataBatch to RestierBreakdanceTestBase, and developers using RESTier will have to add the same UseODataBatch in order to enable batch support in .NET Core.

Issue #2: In the JSON format, the content-type of batches within a response include odata.streaming=true in .NET Core, but not net472. Not sure why this difference, but both are valid so I just accounted for this in the tests. 

Issue #3: There were some threading issues with how we handled the Changeset entries.  First, entries were kept in a List<T>, which is not threadsafe, although we had multiple threads adding to the list, so I made it a ConcurrentQueue.  Second, and harder to track down, was the fact that we were lazy-instantiating the collection (list or queue) underlying the entries for the changeset.  This was leading to a race condition where one thread would check to see if it existed and, since it didn't, would create it. but before that creation completed, the second thread would see it didn't exist and also create it, but the new one wouldn't include the entry from the first thread. So, I moved creation of the collection (ConcurrentQueue) to the constructors.

### Checklist (Uncheck if it is not completed)
- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary
none