### PR TITLE
Swagger Support for Restier 1.1 RTM (#742)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ Work on the current version of the protocol (V4) began in April 2012, and was ra
 Coming Soon!
 
 ## Supported Platforms
-Restier 1.0 currently supports the following platforms:
+Restier 1.1 currently supports the following platforms:
 - Classic ASP.NET 5.2.7 and later
-- ASP.NET Core 6.0, 7.0, and 8.0 RC2 (Binaries targeting deprecated versions of .NET are still available on NuGet.org)
+- ASP.NET Core 6.0, 7.0, and 8.0 (Binaries targeting deprecated versions of .NET are still available on NuGet.org)
 - Entity Framework 6.4 and later
 - Entity Framework Core 6.0 and later
 
@@ -54,21 +54,20 @@ Restier is made up of the following components:
 - **Microsoft.Restier.AspNet & Microsoft.Restier.AspNetCore:** Plugs into the OData/WebApi processing pipeline and provides query interception capabilities.
 - **Microsoft.Restier.Core:** The base library that contains the core convention-based interception framework.
 - **Microsoft.Restier.EntityFramework & Microsoft.Restier.EntityFramework:** Translates intercepted queries down to the database level to be executed.
-- **Microsoft.Restier.Breakdance:** Unit test Restier services and components in-memory without spnning up a separate IIS instance, as well as verify the availability of your custom convention-based interceptors.
+- **Microsoft.Restier.Breakdance:** Unit test Restier services and components in-memory without spinning up a separate IIS instance, as well as verify the availability of your custom convention-based interceptors.
+- **Microsoft.Restier.AspNetCore.Swagger:** Automatically generates Swagger documentation for your ASP.NET Core Restier service.
 
 ## Ecosystem
 Restier is used in solutions from:
 - [BurnRate.io](https://burnrate.io)
-- [CloudNimble, Inc.](https://nimbleapps.cloud)
+- [CloudNimble](https://nimbleapps.cloud)
 - [Florida Agency for Health Care Administration](https://ahca.myflorida.com)
+- [Microsoft](https://graph.microsoft.com)
 - [Miller's Ale House](https://millersalehouse.com)
+- [NoCore](https://nocore.nl)
 
 ## Community
 After a couple years in statis, Restier is in active development once again. The project is lead by Robert McLaws and Mike Pizzo.
-
-### Weekly Standups
-The core development team meets twice a month on Microsoft Teams to discuss pressing items and work through the issues list. A history of
-those meetings can be found in the Wiki.
 
 ### Contributing
 If you'd like to help out with the project, our Contributor's Handbook is also located in the Wiki.
@@ -79,7 +78,7 @@ Security issues and bugs should be reported privately, via email, to the Microso
 
 ## Contributors
 
-Special thanks to everyone involved in making RESTier the best API development platform for .NET. The following people
+Special thanks to everyone involved in making Restier the best API development platform for .NET. The following people
 have made various contributions to the codebase:
 
 | Microsoft     | External         |
@@ -90,9 +89,9 @@ have made various contributions to the codebase:
 | Vincent He    | Kemal M          |
 | Dong Liu      | Mateusz Malicki  |
 | Layla Liu     | Robert McLaws    |
-| Fan Ouyang    | Jan-Willem Spuij |
-| Mike Pizzo    | Chris Woodruff   |
-| Congyong S    |                  |
+| Fan Ouyang    | Micah Rairdon    |
+| Mike Pizzo    | Jan-Willem Spuij |
+| Congyong S    | Chris Woodruff   |
 | Mark Stafford |                  |
 | Ray Yao       |                  |
 

--- a/src/Microsoft.Restier.AspNetCore.Swagger/Extensions/IApplicationBuilderExtensions.cs
+++ b/src/Microsoft.Restier.AspNetCore.Swagger/Extensions/IApplicationBuilderExtensions.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Restier.Core;
+
+namespace Microsoft.AspNetCore.Builder
+{
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static class Restier_AspNetCore_Swagger_IApplicationBuilderExtensions
+    {
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="app"></param>
+        /// <param name="addUI"></param>
+        /// <returns></returns>
+        public static IApplicationBuilder UseRestierSwagger(this IApplicationBuilder app, bool addUI = true)
+        {
+            app.UseSwagger();
+
+            if (addUI)
+            {
+                app.UseSwaggerUI(c =>
+                {
+                    var rrb = app.ApplicationServices.GetRequiredService<RestierRouteBuilder>();
+                    foreach (var route in rrb.Routes)
+                    { 
+                        c.SwaggerEndpoint($"/swagger/{route.Key}/swagger.json", route.Value.RouteName);
+                    }
+                });
+            }
+            return app;
+        }
+
+    }
+
+}

--- a/src/Microsoft.Restier.AspNetCore.Swagger/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Microsoft.Restier.AspNetCore.Swagger/Extensions/IServiceCollectionExtensions.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using Microsoft.OpenApi.OData;
+using Microsoft.Restier.AspNetCore.Swagger;
+using Swashbuckle.AspNetCore.Swagger;
+using System;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static class Restier_AspNetCore_Swagger_IServiceCollectionExtensions
+    {
+
+        /// <summary>
+        /// Adds the required services to use Swagger with Restier.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> to register Swagger services with.</param>
+        /// <param name="openApiSettings">An <see cref="Action{OpenApiConvertSettings}"/> that allows you to configure the core Swagger output.</param>
+        /// <returns></returns>
+        public static IServiceCollection AddRestierSwagger(this IServiceCollection services, Action<OpenApiConvertSettings> openApiSettings = null)
+        {
+            services.AddScoped<ISwaggerProvider, RestierSwaggerProvider>();
+            if (openApiSettings is not null)
+            {
+                services.AddScoped(sp => openApiSettings);
+            }
+            return services;
+        }
+
+    }
+
+}

--- a/src/Microsoft.Restier.AspNetCore.Swagger/Microsoft.Restier.AspNetCore.Swagger.csproj
+++ b/src/Microsoft.Restier.AspNetCore.Swagger/Microsoft.Restier.AspNetCore.Swagger.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFrameworks>net8.0;net7.0;net6.0;</TargetFrameworks>
+		<StrongNamePublicKey>$(StrongNamePublicKey)</StrongNamePublicKey>
+		<DocumentationFile>$(DocumentationFile)\$(AssemblyName).xml</DocumentationFile>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Microsoft.Restier.AspNetCore\Microsoft.Restier.AspNetCore.csproj" />
+		<ProjectReference Include="..\Microsoft.Restier.Core\Microsoft.Restier.Core.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.OpenApi.OData" Version="[1.*, 2.0.0)" />
+		<PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="[6.*, 7.0.0)" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="[6.*, 7.0.0)" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Include="README.md" Pack="true" PackagePath="">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
+
+</Project>

--- a/src/Microsoft.Restier.AspNetCore.Swagger/README.md
+++ b/src/Microsoft.Restier.AspNetCore.Swagger/README.md
@@ -1,0 +1,104 @@
+# Microsoft Restier - OData Made Simple
+
+[Releases](https://github.com/OData/RESTier/releases)&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;Documentation&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[OData v4.01 Documentation](https://www.odata.org/documentation/)
+
+<!--[![Build Status][devops-build-img]][devops-build] [![Release Status][devops-release-img]][devops-release] <br />
+[![Code of Conduct][code-of-conduct-img]][code-of-conduct] [![Twitter][twitter-img]][twitter-intent]-->
+
+## Swagger for Restier ASP.NET Core
+
+This package helps you quickly implement OpenAPI's Swagger.json and Swagger UI in your Restier service in just a few lines of code.
+
+## Supported Platforms
+[Microsoft.Restier.AspNetCore.Swagger](https://www.nuget.org/packages/Microsoft.Restier.AspNetCore.Swagger) 1.1 currently supports the following platforms:
+- ASP.NET Core 6.0, 7.0, and 8.0 via Endpoint Routing
+
+## Getting Started
+Building OpenAPI into your Restier project is easy!
+
+### Step 1: Install [Microsoft.Restier.AspNetCore.Swagger](https://www.nuget.org/packages/Microsoft.Restier.AspNetCore.Swagger/1.1.0-CI-20231125-225528)
+- Add the package above to your API project.
+- **[Optional]** Change the version of your Restier packages to `1.*-*` so you always get the latest version.
+
+### Step 2: Convert to Endpoint Routing (Part 1)
+- Add the new parameter to the end of your `services.AddRestier()` call:
+```cs
+    services.AddRestier((builder) =>
+    {
+        ...
+    }, true); // <-- @robertmclaws: This parameter adds Endpoint Routing support.
+```
+
+### Step 3: Register Swagger Services
+- Add the line below immediately after the `services.AddRestier()` call:
+```cs
+services.AddRestierSwagger();
+```
+- There is an overload to this method that takes an `Action<OpenApiConvertSettings>` that will let you change the configuration of the generated Swagger definition.
+
+### Step 4: Convert to Endpoint Routing & Use Swagger (Part 2)
+- Replace your existing `Configure` code with the following (don't forget your customizations):
+```cs
+    public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+    {
+        if (env.IsDevelopment())
+        {
+            app.UseDeveloperExceptionPage();
+        }
+
+        app.UseRestierBatching();
+        app.UseRouting();
+
+        app.UseAuthorization();
+        // @robertmclaws: This line is optional but helps with leveraging ClaimsPrincipal.Current for cross-platform business logic.
+        app.UseClaimsPrincipals();
+
+        app.UseEndpoints(endpoints =>
+        {
+            endpoints.Select().Expand().Filter().OrderBy().MaxTop(100).Count().SetTimeZoneInfo(TimeZoneInfo.Utc);
+            endpoints.MapRestier(builder =>
+            {
+                builder.MapApiRoute<YOURAPITYPEHERE>("ROUTENAME", "ROUTEPREFIX", true);
+            });
+        });
+
+        app.UseRestierSwagger(true);
+    }
+```
+- On the last line, the boolean specifies whether or not to use SwaggerUI. If you want to control more of the UI configuration, use `services.Configure<SwaggerUIOptions>();` in your `ConfigureServices()` method.
+
+### Step 5: Browse Swagger Resources
+- Browse to `/swagger/ROUTENAME/swagger.json` to see the generated Swagger definition.
+- Browse to `/swagger` to see the Swagger UI.
+
+## Reporting Security Issues
+
+Security issues and bugs should be reported privately, via email, to the Microsoft Security Response Center (MSRC) <secure@microsoft.com>. You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Further information, including the MSRC PGP key, can be found in the [Security TechCenter](https://www.microsoft.com/msrc/faqs-report-an-issue). You can also find these instructions in this repo's [SECURITY.md](./SECURITY.md).
+
+## Contributors
+
+Special thanks to everyone involved in making Restier the best API development platform for .NET. The following people have made various contributions to this package:
+
+| External         |
+|------------------|
+| Cengiz Ilerler   |
+| Robert McLaws    |
+| Micah Rairdon    |
+
+<!--
+Link References
+-->
+
+[devops-build]:https://dev.azure.com/dotnet/OData/_build?definitionId=89
+[devops-release]:https://dev.azure.com/dotnet/odata/_release?view=all&definitionId=2
+[twitter-intent]:https://twitter.com/intent/tweet?url=https%3A%2F%2Fgithub.com%2FOData%2FRESTier&via=robertmclaws&text=Check%20out%20Restier%21%20It%27s%20the%20simple%2C%20queryable%20framework%20for%20building%20data-driven%20APIs%20in%20.NET%21&hashtags=odata
+[code-of-conduct]:https://opensource.microsoft.com/codeofconduct/
+
+[devops-build-img]:https://img.shields.io/azure-devops/build/dotnet/odata/89.svg?style=for-the-badge&logo=azuredevops
+[devops-release-img]:https://img.shields.io/azure-devops/release/dotnet/f69f4a5b-2486-494e-ad83-7ba2b889f752/2/2.svg?style=for-the-badge&logo=azuredevops
+[nightly-feed-img]:https://img.shields.io/badge/continuous%20integration-feed-0495dc.svg?style=for-the-badge&logo=nuget&logoColor=fff
+[github-version-img]:https://img.shields.io/github/release/ryanoasis/nerd-fonts.svg?style=for-the-badge
+[gitter-img]:https://img.shields.io/gitter/room/nwjs/nw.js.svg?style=for-the-badge
+[code-climate-img]:https://img.shields.io/codeclimate/issues/github/ryanoasis/nerd-fonts.svg?style=for-the-badge
+[code-of-conduct-img]: https://img.shields.io/badge/code%20of-conduct-00a1f1.svg?style=for-the-badge&logo=windows
+[twitter-img]:https://img.shields.io/badge/share-on%20twitter-55acee.svg?style=for-the-badge&logo=twitter

--- a/src/Microsoft.Restier.AspNetCore.Swagger/RestierSwaggerProvider.cs
+++ b/src/Microsoft.Restier.AspNetCore.Swagger/RestierSwaggerProvider.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using Microsoft.AspNet.OData;
+using Microsoft.AspNet.OData.Query;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData.Edm;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.OData;
+using Swashbuckle.AspNetCore.Swagger;
+using System;
+
+namespace Microsoft.Restier.AspNetCore.Swagger
+{
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public class RestierSwaggerProvider : ISwaggerProvider
+    {
+
+        private readonly IHttpContextAccessor httpContextAccessor;
+        private readonly IPerRouteContainer perRouteContainer;
+        private readonly Action<OpenApiConvertSettings> openApiSettings;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="httpContextAccessor"></param>
+        /// <param name="perRouteContainer"></param>
+        /// <param name="openApiSettings"></param>
+        public RestierSwaggerProvider(IHttpContextAccessor httpContextAccessor, IPerRouteContainer perRouteContainer, Action<OpenApiConvertSettings> openApiSettings = null)
+        {
+            this.httpContextAccessor = httpContextAccessor;
+            this.perRouteContainer = perRouteContainer;
+            this.openApiSettings = openApiSettings;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="documentName"></param>
+        /// <param name="host"></param>
+        /// <param name="basePath"></param>
+        /// <returns></returns>
+        public OpenApiDocument GetSwagger(string documentName, string host = null, string basePath = null)
+        {
+            var services = perRouteContainer.GetODataRootContainer(documentName);
+            var model = services.GetRequiredService<IEdmModel>();
+            var odataValidationSettings = services.GetRequiredService<ODataValidationSettings>();
+            var defaultQuerySettings = services.GetRequiredService<DefaultQuerySettings>();
+
+            // @robertmclaws: Start off by setting defaults, but allow the user to override it.
+            var settings = new OpenApiConvertSettings { TopExample = odataValidationSettings?.MaxTop ?? defaultQuerySettings?.MaxTop ?? 5 };
+            openApiSettings?.Invoke(settings);
+
+            // @robertmclaws: The host defaults internally to localhost; isn't set automatically.
+            var requestHost = httpContextAccessor.HttpContext.Request.Host.Value;
+            if (!settings.ServiceRoot.ToString().StartsWith(requestHost))
+            {
+                settings.ServiceRoot = new Uri($"{httpContextAccessor.HttpContext.Request.Scheme}://{requestHost}");
+            }
+
+            return model.ConvertToOpenApi(settings);
+        }
+
+    }
+
+}

--- a/src/Microsoft.Restier.AspNetCore/Extensions/Restier_IEndpointRouteBuilderExtensions.cs
+++ b/src/Microsoft.Restier.AspNetCore/Extensions/Restier_IEndpointRouteBuilderExtensions.cs
@@ -65,10 +65,10 @@ namespace Microsoft.Restier.AspNetCore
 
             var perRouteContainer = routeBuilder.ServiceProvider.GetRequiredService<IPerRouteContainer>();
             var apiBuilderAction = routeBuilder.ServiceProvider.GetRequiredService<Action<RestierApiBuilder>>();
+            var rrb = routeBuilder.ServiceProvider.GetRequiredService<RestierRouteBuilder>();
 
             perRouteContainer.BuilderFactory = () => new RestierContainerBuilder(apiBuilderAction);
 
-            var rrb = new RestierRouteBuilder();
             configureRoutesAction.Invoke(rrb);
 
             foreach (var route in rrb.Routes)

--- a/src/Microsoft.Restier.AspNetCore/Extensions/Restier_IRouteBuilderExtensions.cs
+++ b/src/Microsoft.Restier.AspNetCore/Extensions/Restier_IRouteBuilderExtensions.cs
@@ -47,10 +47,10 @@ namespace Microsoft.Restier.AspNetCore
 
             var perRouteContainer = routeBuilder.ServiceProvider.GetRequiredService<IPerRouteContainer>();
             var apiBuilderAction = routeBuilder.ServiceProvider.GetRequiredService<Action<RestierApiBuilder>>();
+            var rrb = routeBuilder.ServiceProvider.GetRequiredService<RestierRouteBuilder>();
 
             perRouteContainer.BuilderFactory = () => new RestierContainerBuilder(apiBuilderAction);
 
-            var rrb = new RestierRouteBuilder();
             configureRoutesAction.Invoke(rrb);
 
             foreach (var route in rrb.Routes)

--- a/src/Microsoft.Restier.AspNetCore/Extensions/Restier_IServiceCollectionExtensions.cs
+++ b/src/Microsoft.Restier.AspNetCore/Extensions/Restier_IServiceCollectionExtensions.cs
@@ -122,6 +122,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             // @robertmclaws: We're going to store this in the core DI container so we can grab it later and configure the APIs.
             services.AddSingleton(sp => configureApisAction);
+            services.AddSingleton<RestierRouteBuilder>();
 
             if (useEndpointRouting)
             {

--- a/src/Microsoft.Restier.Core/Extensions/ApiBaseExtensions.cs
+++ b/src/Microsoft.Restier.Core/Extensions/ApiBaseExtensions.cs
@@ -16,6 +16,7 @@ using Microsoft.Restier.Core.Query;
 
 namespace Microsoft.Restier.Core
 {
+
     /// <summary>
     /// Represents the API engine and provides a set of static
     /// (Shared in Visual Basic) methods for interacting with objects
@@ -439,5 +440,7 @@ namespace Microsoft.Restier.Core
         }
 
         #endregion
+
     }
+
 }

--- a/src/Microsoft.Restier.Core/Microsoft.Restier.Core.csproj
+++ b/src/Microsoft.Restier.Core/Microsoft.Restier.Core.csproj
@@ -19,36 +19,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-			<_Parameter1>Microsoft.Restier.AspNet, $(StrongNamePublicKey)</_Parameter1>
-		</AssemblyAttribute>
-		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-			<_Parameter1>Microsoft.Restier.AspNetCore, $(StrongNamePublicKey)</_Parameter1>
-		</AssemblyAttribute>
-		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-			<_Parameter1>Microsoft.Restier.EntityFramework, $(StrongNamePublicKey)</_Parameter1>
-		</AssemblyAttribute>
-		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-			<_Parameter1>Microsoft.Restier.EntityFrameworkCore, $(StrongNamePublicKey)</_Parameter1>
-		</AssemblyAttribute>
-		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-			<_Parameter1>Microsoft.Restier.Tests.EntityFramework, $(StrongNamePublicKey)</_Parameter1>
-		</AssemblyAttribute>
-		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-			<_Parameter1>Microsoft.Restier.Tests.AspNet, $(StrongNamePublicKey)</_Parameter1>
-		</AssemblyAttribute>
-		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-			<_Parameter1>Microsoft.Restier.Tests.AspNetCore, $(StrongNamePublicKey)</_Parameter1>
-		</AssemblyAttribute>
-		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-			<_Parameter1>Microsoft.Restier.Tests.AspNetCorePlusEF6, $(StrongNamePublicKey)</_Parameter1>
-		</AssemblyAttribute>
-		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-			<_Parameter1>Microsoft.Restier.Tests.Shared, $(StrongNamePublicKey)</_Parameter1>
-		</AssemblyAttribute>
-	</ItemGroup>
-
-	<ItemGroup>
 		<PackageReference Include="Ben.TypeDictionary" Version="[0.*, 2.0.0)" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 		<PackageReference Include="Microsoft.OData.Core" Version="[7.*, 8.0.0)" />
@@ -91,6 +61,39 @@
 			<LastGenOutput>Resources.Designer.cs</LastGenOutput>
 			<CustomToolNamespace>Microsoft.Restier.Core</CustomToolNamespace>
 		</EmbeddedResource>
+	</ItemGroup>
+
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+			<_Parameter1>Microsoft.Restier.AspNet, $(StrongNamePublicKey)</_Parameter1>
+		</AssemblyAttribute>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+			<_Parameter1>Microsoft.Restier.AspNetCore, $(StrongNamePublicKey)</_Parameter1>
+		</AssemblyAttribute>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+			<_Parameter1>Microsoft.Restier.AspNetCore.Swagger, $(StrongNamePublicKey)</_Parameter1>
+		</AssemblyAttribute>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+			<_Parameter1>Microsoft.Restier.EntityFramework, $(StrongNamePublicKey)</_Parameter1>
+		</AssemblyAttribute>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+			<_Parameter1>Microsoft.Restier.EntityFrameworkCore, $(StrongNamePublicKey)</_Parameter1>
+		</AssemblyAttribute>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+			<_Parameter1>Microsoft.Restier.Tests.EntityFramework, $(StrongNamePublicKey)</_Parameter1>
+		</AssemblyAttribute>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+			<_Parameter1>Microsoft.Restier.Tests.AspNet, $(StrongNamePublicKey)</_Parameter1>
+		</AssemblyAttribute>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+			<_Parameter1>Microsoft.Restier.Tests.AspNetCore, $(StrongNamePublicKey)</_Parameter1>
+		</AssemblyAttribute>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+			<_Parameter1>Microsoft.Restier.Tests.AspNetCorePlusEF6, $(StrongNamePublicKey)</_Parameter1>
+		</AssemblyAttribute>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+			<_Parameter1>Microsoft.Restier.Tests.Shared, $(StrongNamePublicKey)</_Parameter1>
+		</AssemblyAttribute>
 	</ItemGroup>
 
 </Project>

--- a/src/Microsoft.Restier.Core/Startup/RestierContainerBuilder.cs
+++ b/src/Microsoft.Restier.Core/Startup/RestierContainerBuilder.cs
@@ -117,7 +117,6 @@ namespace Microsoft.Restier.Core
 
             Type apiType = null;
 
-
             if (routeBuilder.Routes.Any())
             {
                 if (routeBuilder.Routes.ContainsKey(RouteName))
@@ -207,5 +206,6 @@ namespace Microsoft.Restier.Core
         }
 
         #endregion
+
     }
 }

--- a/src/Microsoft.Restier.Samples.Northwind.AspNetCore/Microsoft.Restier.Samples.Northwind.AspNetCore.csproj
+++ b/src/Microsoft.Restier.Samples.Northwind.AspNetCore/Microsoft.Restier.Samples.Northwind.AspNetCore.csproj
@@ -20,6 +20,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<ProjectReference Include="..\Microsoft.Restier.AspNetCore.Swagger\Microsoft.Restier.AspNetCore.Swagger.csproj" />
 		<ProjectReference Include="..\Microsoft.Restier.AspNetCore\Microsoft.Restier.AspNetCore.csproj" />
 		<ProjectReference Include="..\Microsoft.Restier.EntityFrameworkCore\Microsoft.Restier.EntityFrameworkCore.csproj" />
 	</ItemGroup>

--- a/src/Microsoft.Restier.Samples.Northwind.AspNetCore/Program.cs
+++ b/src/Microsoft.Restier.Samples.Northwind.AspNetCore/Program.cs
@@ -1,11 +1,8 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Microsoft.Restier.Samples.Northwind.AspNetCore
 {

--- a/src/Microsoft.Restier.Samples.Northwind.AspNetCore/Startup.cs
+++ b/src/Microsoft.Restier.Samples.Northwind.AspNetCore/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
 using Microsoft.AspNet.OData.Extensions;
 using Microsoft.AspNet.OData.Query;
 using Microsoft.AspNetCore.Authorization;
@@ -60,6 +63,8 @@ namespace Microsoft.Restier.Samples.Northwind.AspNetCore
                 });
             }, true);
 
+            services.AddRestierSwagger();
+
             //RWM: Since AddRestier calls .AddAuthorization(), you can uncomment the line below if you want every request to be authenticated.
             //services.Configure<AuthorizationOptions>(options => options.FallbackPolicy = new AuthorizationPolicyBuilder().RequireAuthenticatedUser().Build());
         }
@@ -90,6 +95,8 @@ namespace Microsoft.Restier.Samples.Northwind.AspNetCore
                     builder.MapApiRoute<NorthwindApi>("ApiV1", "", true);
                 });
             });
+
+            app.UseRestierSwagger(true);
         }
 
     }

--- a/src/Microsoft.Restier.Tests.AspNetCore.Swagger/Extensions/IApplicationBuilderExtensionsTests.cs
+++ b/src/Microsoft.Restier.Tests.AspNetCore.Swagger/Extensions/IApplicationBuilderExtensionsTests.cs
@@ -1,0 +1,11 @@
+﻿namespace Microsoft.Restier.Tests.AspNetCore.Swagger.Extensions
+{
+
+    public class IApplicationBuilderExtensionsTests
+    {
+
+
+
+    }
+
+}

--- a/src/Microsoft.Restier.Tests.AspNetCore.Swagger/Extensions/IServiceCollectionExtensionsTests.cs
+++ b/src/Microsoft.Restier.Tests.AspNetCore.Swagger/Extensions/IServiceCollectionExtensionsTests.cs
@@ -1,0 +1,30 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Restier.Tests.AspNetCore.Swagger.Extensions
+{
+
+    [TestClass]
+    public class IServiceCollectionExtensionsTests
+    {
+
+        [TestMethod]
+        public void AddRestierSwagger_NoSettingsAction()
+        {
+            var collection = new ServiceCollection();
+            collection.AddRestierSwagger();
+            collection.Should().ContainSingle();
+        }
+
+        [TestMethod]
+        public void AddRestierSwagger_SettingsAction()
+        {
+            var collection = new ServiceCollection();
+            collection.AddRestierSwagger(settings => settings.AddAlternateKeyPaths = true);
+            collection.Should().HaveCount(2);
+        }
+
+    }
+
+}

--- a/src/Microsoft.Restier.Tests.AspNetCore.Swagger/Microsoft.Restier.Tests.AspNetCore.Swagger.csproj
+++ b/src/Microsoft.Restier.Tests.AspNetCore.Swagger/Microsoft.Restier.Tests.AspNetCore.Swagger.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net7.0;net6.0;</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Restier.AspNetCore.Swagger\Microsoft.Restier.AspNetCore.Swagger.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/RESTier.sln
+++ b/src/RESTier.sln
@@ -29,7 +29,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.props = Directory.Build.props
 		dotnet-logo.png = dotnet-logo.png
 		global.json = global.json
-		README.md = README.md
+		..\README.md = ..\README.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{DB42E0B8-C0C7-4DE4-9437-2B2A229B5F8F}"
@@ -73,6 +73,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Restier.Tests.AspNetCorePlusEF6", "Microsoft.Restier.Tests.AspNetCorePlusEF6\Microsoft.Restier.Tests.AspNetCorePlusEF6.csproj", "{42646361-1D62-4AB7-9735-009EB2DD0F38}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Restier.Tests.EntityFrameworkCore", "Microsoft.Restier.Tests.EntityFrameworkCore\Microsoft.Restier.Tests.EntityFrameworkCore.csproj", "{2DB7E862-69AE-43E2-9EC4-C1491E8BA28F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Restier.AspNetCore.Swagger", "Microsoft.Restier.AspNetCore.Swagger\Microsoft.Restier.AspNetCore.Swagger.csproj", "{5E2A4379-EB39-4AED-9FBA-E216DD2B982F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Restier.Tests.AspNetCore.Swagger", "Microsoft.restier.Tests.AspNetCore.Swagger\Microsoft.Restier.Tests.AspNetCore.Swagger.csproj", "{DE19D3BE-7D76-4081-84EF-152E56B10535}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -156,6 +160,14 @@ Global
 		{2DB7E862-69AE-43E2-9EC4-C1491E8BA28F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2DB7E862-69AE-43E2-9EC4-C1491E8BA28F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2DB7E862-69AE-43E2-9EC4-C1491E8BA28F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5E2A4379-EB39-4AED-9FBA-E216DD2B982F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5E2A4379-EB39-4AED-9FBA-E216DD2B982F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5E2A4379-EB39-4AED-9FBA-E216DD2B982F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5E2A4379-EB39-4AED-9FBA-E216DD2B982F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DE19D3BE-7D76-4081-84EF-152E56B10535}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DE19D3BE-7D76-4081-84EF-152E56B10535}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DE19D3BE-7D76-4081-84EF-152E56B10535}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DE19D3BE-7D76-4081-84EF-152E56B10535}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -188,6 +200,8 @@ Global
 		{4ED74763-33E0-432A-B009-1423F7FC03CF} = {2BF9B9A4-E4EA-447D-9BAF-AF1A6840A24F}
 		{42646361-1D62-4AB7-9735-009EB2DD0F38} = {2BF9B9A4-E4EA-447D-9BAF-AF1A6840A24F}
 		{2DB7E862-69AE-43E2-9EC4-C1491E8BA28F} = {2BF9B9A4-E4EA-447D-9BAF-AF1A6840A24F}
+		{5E2A4379-EB39-4AED-9FBA-E216DD2B982F} = {9D3D8728-C31B-4D5E-B471-79A9DBBA0E58}
+		{DE19D3BE-7D76-4081-84EF-152E56B10535} = {2BF9B9A4-E4EA-447D-9BAF-AF1A6840A24F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5A37189C-A5E1-4871-AF65-8EBF2DA60FE3}


### PR DESCRIPTION
* Implementing Official Swagger Support (#740)
- Inject the RestierRouteBuilder so it can be accessed by the Swagger setup.
- Implement version of https://github.com/OData/RESTier/issues/720#issuecomment-1826147986
- Automagically configure OpenApi to handle the endpoints correctly.
- Swagger validation improvements & first unit tests
- Documentation changes, including a Readme in the Swagger package (more coming soon).
- Update README.md

Co-authored by @Tiberriver256.

### Issues
*This pull request fixes issue #xxx.*  

### Description
*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)
- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary
*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
