### PR TITLE
Observe the route prefix in RestierSwaggerProvider

### DIFF
--- a/src/Microsoft.Restier.AspNetCore.Swagger/RestierSwaggerProvider.cs
+++ b/src/Microsoft.Restier.AspNetCore.Swagger/RestierSwaggerProvider.cs
@@ -56,11 +56,10 @@ namespace Microsoft.Restier.AspNetCore.Swagger
             openApiSettings?.Invoke(settings);
 
             // @robertmclaws: The host defaults internally to localhost; isn't set automatically.
-            var requestHost = httpContextAccessor.HttpContext.Request.Host.Value;
-            if (!settings.ServiceRoot.ToString().StartsWith(requestHost))
-            {
-                settings.ServiceRoot = new Uri($"{httpContextAccessor.HttpContext.Request.Scheme}://{requestHost}");
-            }
+            var request = httpContextAccessor.HttpContext?.Request ?? throw new InvalidOperationException("The HttpContext is not available");
+            var routePrefix = perRouteContainer.GetRoutePrefix(documentName);
+            var path = string.IsNullOrEmpty(routePrefix) ? "" : $"{routePrefix}/";
+            settings.ServiceRoot = new Uri($"{request.Scheme}://{request.Host}/{path}");
 
             return model.ConvertToOpenApi(settings);
         }


### PR DESCRIPTION
## Before this commit

When mapping a Restier route with a non empty route prefix, the generated swagger file does not include the route prefix in the `servers[0].url` property.

```csharp
app.MapRestier(restier => restier.MapApiRoute<EntityFrameworkApi<MyDbContext>>(routeName: "RestierDefault", routePrefix: "api"));
```

❌ The generated url is `http://localhost:5000`, making all requests from SwaggerUI fail with 404 errors.

## After this commit

The route prefix is included in the generated swagger file in the `servers[0].url` property.

✅ The generated url is `http://localhost:5000/api/`, making SwaggerUI usable.

Fixes #749