### PR TITLE
Batchhandler results in an error when doing bulk updates.

### DIFF
--- a/src/Microsoft.Restier.AspNet/Batch/RestierBatchChangeSetRequestItem.cs
+++ b/src/Microsoft.Restier.AspNet/Batch/RestierBatchChangeSetRequestItem.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -54,7 +55,7 @@ namespace Microsoft.Restier.AspNet.Batch
             };
             SetChangeSetProperty(changeSetProperty);
 
-            var contentIdToLocationMapping = new Dictionary<string, string>();
+            var contentIdToLocationMapping = new ConcurrentDictionary<string, string>();
             var responseTasks = new List<Task<Task<HttpResponseMessage>>>();
 
             foreach (var request in Requests)

--- a/src/Microsoft.Restier.AspNetCore/Batch/RestierBatchChangeSetRequestItem.cs
+++ b/src/Microsoft.Restier.AspNetCore/Batch/RestierBatchChangeSetRequestItem.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -51,7 +52,7 @@ namespace Microsoft.Restier.AspNetCore.Batch
             };
             SetChangeSetProperty(changeSetProperty);
 
-            var contentIdToLocationMapping = new Dictionary<string, string>();
+            var contentIdToLocationMapping = new ConcurrentDictionary<string, string>();
             var responseTasks = new List<Task<Task<HttpContext>>>();
 
             foreach (var context in Contexts)


### PR DESCRIPTION
### Issues
*This pull request fixes issue #760 

### Description
Concurrent dictionary to resolve the crashes.

### Checklist (Uncheck if it is not completed)
- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary
Hopefully It won't have more concurrency errors. The default method doesn't resolve the requests all at the same time, and I don't believe it is tested properly after this change. 
